### PR TITLE
Add log fields getter

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -226,7 +226,7 @@ func (app *App) Start(ctx context.Context) (err error) {
 		case <-done:
 			return
 		case <-time.After(StartWarningAfter):
-			l := app.statLogger(app.stopStat, log).With(zap.String("in_progress", currentComponentStarting))
+			l := app.statLogger(app.startStat, log).With(zap.String("in_progress", currentComponentStarting))
 			l.Warn("components start in progress")
 		}
 	}()
@@ -261,7 +261,7 @@ func (app *App) Start(ctx context.Context) (err error) {
 	}
 
 	close(done)
-	l := app.statLogger(app.stopStat, log)
+	l := app.statLogger(app.startStat, log)
 
 	if app.startStat.SpentMsTotal > StartWarningAfter.Milliseconds() {
 		l.Warn("all components started")

--- a/app/app.go
+++ b/app/app.go
@@ -50,7 +50,7 @@ type ComponentRunnable interface {
 }
 
 type ComponentLogFieldsGetter interface {
-	// GetLogFields returns additional useful fields for logs to debug log app start time or something else in the future
+	// GetLogFields returns additional useful fields for logs to debug long app start/stop duration or something else in the future
 	// You don't need to provide the component name in the field's Key, because it will be added automatically
 	GetLogFields() []zap.Field
 }


### PR DESCRIPTION
- allow components to add additional info for the long start/stop logger. It is useful to understand the context, e.g. local repo was missing
- stopStat was used instead of startStat for the Start debug