### PR TITLE
GO-3921: add new network compatibility status

### DIFF
--- a/commonspace/spaceutils_test.go
+++ b/commonspace/spaceutils_test.go
@@ -364,6 +364,10 @@ var _ coordinatorclient.CoordinatorClient = (*mockCoordinatorClient)(nil)
 type mockCoordinatorClient struct {
 }
 
+func (m mockCoordinatorClient) IsNetworkNeedsUpdate(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
 func (m mockCoordinatorClient) SpaceMakeShareable(ctx context.Context, spaceId string) (err error) {
 	return nil
 }

--- a/coordinator/coordinatorclient/coordinatorclient.go
+++ b/coordinator/coordinatorclient/coordinatorclient.go
@@ -4,7 +4,6 @@ package coordinatorclient
 import (
 	"context"
 	"errors"
-	"github.com/anyproto/any-sync/net/secureservice"
 
 	"storj.io/drpc"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/anyproto/any-sync/net/peer"
 	"github.com/anyproto/any-sync/net/pool"
 	"github.com/anyproto/any-sync/net/rpc/rpcerr"
+	"github.com/anyproto/any-sync/net/secureservice"
 	"github.com/anyproto/any-sync/nodeconf"
 	"github.com/anyproto/any-sync/util/cidutil"
 	"github.com/anyproto/any-sync/util/crypto"

--- a/coordinator/coordinatorclient/coordinatorclient.go
+++ b/coordinator/coordinatorclient/coordinatorclient.go
@@ -361,7 +361,7 @@ func (c *coordinatorClient) IsNetworkNeedsUpdate(ctx context.Context) (bool, err
 	if err != nil {
 		return false, err
 	}
-	return version != secureservice.ProtoVersion, nil
+	return secureservice.ProtoVersion < version, nil
 }
 
 func (c *coordinatorClient) doClient(ctx context.Context, f func(cl coordinatorproto.DRPCCoordinatorClient) error) error {

--- a/coordinator/coordinatorclient/coordinatorclient.go
+++ b/coordinator/coordinatorclient/coordinatorclient.go
@@ -4,6 +4,7 @@ package coordinatorclient
 import (
 	"context"
 	"errors"
+	"github.com/anyproto/any-sync/net/secureservice"
 
 	"storj.io/drpc"
 
@@ -40,6 +41,7 @@ type CoordinatorClient interface {
 	SpaceMakeShareable(ctx context.Context, spaceId string) (err error)
 	SpaceMakeUnshareable(ctx context.Context, spaceId, aclId string) (err error)
 	NetworkConfiguration(ctx context.Context, currentId string) (*coordinatorproto.NetworkConfigurationResponse, error)
+	IsNetworkNeedsUpdate(ctx context.Context) (bool, error)
 	DeletionLog(ctx context.Context, lastRecordId string, limit int) (records []*coordinatorproto.DeletionLogRecord, err error)
 
 	IdentityRepoPut(ctx context.Context, identity string, data []*identityrepoproto.Data) (err error)
@@ -348,6 +350,18 @@ func (c *coordinatorClient) AclEventLog(ctx context.Context, accountId, lastReco
 		return nil
 	})
 	return
+}
+
+func (c *coordinatorClient) IsNetworkNeedsUpdate(ctx context.Context) (bool, error) {
+	p, err := c.getPeer(ctx)
+	if err != nil {
+		return false, err
+	}
+	version, err := peer.CtxProtoVersion(p.Context())
+	if err != nil {
+		return false, err
+	}
+	return version != secureservice.ProtoVersion, nil
 }
 
 func (c *coordinatorClient) doClient(ctx context.Context, f func(cl coordinatorproto.DRPCCoordinatorClient) error) error {

--- a/coordinator/coordinatorclient/mock_coordinatorclient/mock_coordinatorclient.go
+++ b/coordinator/coordinatorclient/mock_coordinatorclient/mock_coordinatorclient.go
@@ -5,7 +5,6 @@
 //
 //	mockgen -destination mock_coordinatorclient/mock_coordinatorclient.go github.com/anyproto/any-sync/coordinator/coordinatorclient CoordinatorClient
 //
-
 // Package mock_coordinatorclient is a generated GoMock package.
 package mock_coordinatorclient
 
@@ -188,6 +187,21 @@ func (m *MockCoordinatorClient) Init(arg0 *app.App) error {
 func (mr *MockCoordinatorClientMockRecorder) Init(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockCoordinatorClient)(nil).Init), arg0)
+}
+
+// IsNetworkNeedsUpdate mocks base method.
+func (m *MockCoordinatorClient) IsNetworkNeedsUpdate(arg0 context.Context) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsNetworkNeedsUpdate", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsNetworkNeedsUpdate indicates an expected call of IsNetworkNeedsUpdate.
+func (mr *MockCoordinatorClientMockRecorder) IsNetworkNeedsUpdate(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNetworkNeedsUpdate", reflect.TypeOf((*MockCoordinatorClient)(nil).IsNetworkNeedsUpdate), arg0)
 }
 
 // Name mocks base method.

--- a/coordinator/nodeconfsource/nodeconfsource.go
+++ b/coordinator/nodeconfsource/nodeconfsource.go
@@ -67,17 +67,10 @@ func (n *nodeConfSource) GetLast(ctx context.Context, currentId string) (c nodec
 		}
 	}
 
-	needsUpdate, err := n.cl.IsNetworkNeedsUpdate(ctx)
-	if err != nil {
-		return
-	}
-	if needsUpdate {
-		err = nodeconf.ErrNetworkNeedsUpdate
-	}
 	return nodeconf.Configuration{
 		Id:           res.ConfigurationId,
 		NetworkId:    res.NetworkId,
 		Nodes:        nodes,
 		CreationTime: time.Unix(int64(res.CreationTimeUnix), 0),
-	}, err
+	}, nil
 }

--- a/coordinator/nodeconfsource/nodeconfsource.go
+++ b/coordinator/nodeconfsource/nodeconfsource.go
@@ -66,10 +66,18 @@ func (n *nodeConfSource) GetLast(ctx context.Context, currentId string) (c nodec
 			Types:     types,
 		}
 	}
+
+	needsUpdate, err := n.cl.IsNetworkNeedsUpdate(ctx)
+	if err != nil {
+		return
+	}
+	if needsUpdate {
+		err = nodeconf.ErrNetworkNeedsUpdate
+	}
 	return nodeconf.Configuration{
 		Id:           res.ConfigurationId,
 		NetworkId:    res.NetworkId,
 		Nodes:        nodes,
 		CreationTime: time.Unix(int64(res.CreationTimeUnix), 0),
-	}, nil
+	}, err
 }

--- a/nodeconf/service.go
+++ b/nodeconf/service.go
@@ -31,6 +31,7 @@ const (
 	NetworkCompatibilityStatusOk
 	NetworkCompatibilityStatusError
 	NetworkCompatibilityStatusIncompatible
+	NetworkCompatibilityStatusNeedsUpdate
 )
 
 func New() Service {
@@ -147,6 +148,8 @@ func (s *service) setCompatibilityStatusByErr(err error) {
 		s.compatibilityStatus = NetworkCompatibilityStatusIncompatible
 	case net.ErrUnableToConnect:
 		s.compatibilityStatus = NetworkCompatibilityStatusUnknown
+	case ErrNetworkNeedsUpdate:
+		s.compatibilityStatus = NetworkCompatibilityStatusNeedsUpdate
 	default:
 		s.compatibilityStatus = NetworkCompatibilityStatusError
 	}

--- a/nodeconf/service.go
+++ b/nodeconf/service.go
@@ -112,7 +112,7 @@ func (s *service) updateConfiguration(ctx context.Context) (err error) {
 		return err
 	}
 
-	if err = s.updateCompatibilityStatus(ctx, err); err != nil {
+	if err = s.updateCompatibilityStatus(ctx); err != nil {
 		return err
 	}
 
@@ -123,7 +123,7 @@ func (s *service) updateConfiguration(ctx context.Context) (err error) {
 	return nil
 }
 
-func (s *service) updateCompatibilityStatus(ctx context.Context, err error) error {
+func (s *service) updateCompatibilityStatus(ctx context.Context) error {
 	needsUpdate, checkErr := s.networkProtoVersionChecker.IsNetworkNeedsUpdate(ctx)
 	if checkErr != nil {
 		return checkErr
@@ -131,9 +131,9 @@ func (s *service) updateCompatibilityStatus(ctx context.Context, err error) erro
 	if needsUpdate {
 		s.setCompatibilityStatus(NetworkCompatibilityStatusNeedsUpdate)
 	} else {
-		s.setCompatibilityStatusByErr(err)
+		s.setCompatibilityStatus(NetworkCompatibilityStatusOk)
 	}
-	return err
+	return nil
 }
 
 func (s *service) saveAndSetLastConfiguration(ctx context.Context, last Configuration) error {

--- a/nodeconf/service_test.go
+++ b/nodeconf/service_test.go
@@ -54,6 +54,17 @@ func TestService_NetworkCompatibilityStatus(t *testing.T) {
 		time.Sleep(time.Millisecond * 10)
 		assert.Equal(t, NetworkCompatibilityStatusOk, fx.NetworkCompatibilityStatus())
 	})
+	t.Run("needs update", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		fx.testSource.call = func() (c Configuration, e error) {
+			e = ErrNetworkNeedsUpdate
+			return
+		}
+		fx.run(t)
+		time.Sleep(time.Millisecond * 10)
+		assert.Equal(t, NetworkCompatibilityStatusNeedsUpdate, fx.NetworkCompatibilityStatus())
+	})
 }
 
 func newFixture(t *testing.T) *fixture {

--- a/nodeconf/service_test.go
+++ b/nodeconf/service_test.go
@@ -56,35 +56,42 @@ func TestService_NetworkCompatibilityStatus(t *testing.T) {
 	})
 	t.Run("needs update", func(t *testing.T) {
 		fx := newFixture(t)
+		fx.testCoordinator.needsUpdate = true
 		defer fx.finish(t)
-		fx.testSource.call = func() (c Configuration, e error) {
-			e = ErrNetworkNeedsUpdate
-			return
-		}
 		fx.run(t)
 		time.Sleep(time.Millisecond * 10)
 		assert.Equal(t, NetworkCompatibilityStatusNeedsUpdate, fx.NetworkCompatibilityStatus())
+	})
+	t.Run("network not changed update", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.testSource.err = ErrConfigurationNotChanged
+		defer fx.finish(t)
+		fx.run(t)
+		time.Sleep(time.Millisecond * 10)
+		assert.Equal(t, NetworkCompatibilityStatusError, fx.NetworkCompatibilityStatus())
 	})
 }
 
 func newFixture(t *testing.T) *fixture {
 	fx := &fixture{
-		Service:    New(),
-		a:          new(app.App),
-		testStore:  &testStore{},
-		testSource: &testSource{},
-		testConf:   newTestConf(),
+		Service:         New(),
+		testCoordinator: &testCoordinator{},
+		a:               new(app.App),
+		testStore:       &testStore{},
+		testSource:      &testSource{},
+		testConf:        newTestConf(),
 	}
-	fx.a.Register(fx.testConf).Register(&accounttest.AccountTestService{}).Register(fx.Service).Register(fx.testSource).Register(fx.testStore)
+	fx.a.Register(fx.testConf).Register(&accounttest.AccountTestService{}).Register(fx.Service).Register(fx.testSource).Register(fx.testStore).Register(fx.testCoordinator)
 	return fx
 }
 
 type fixture struct {
 	Service
-	a          *app.App
-	testStore  *testStore
-	testSource *testSource
-	testConf   *testConf
+	a               *app.App
+	testStore       *testStore
+	testSource      *testSource
+	testConf        *testConf
+	testCoordinator *testCoordinator
 }
 
 func (fx *fixture) run(t *testing.T) {
@@ -94,6 +101,17 @@ func (fx *fixture) run(t *testing.T) {
 func (fx *fixture) finish(t *testing.T) {
 	require.NoError(t, fx.a.Close(ctx))
 }
+
+type testCoordinator struct {
+	needsUpdate bool
+}
+
+func (t *testCoordinator) IsNetworkNeedsUpdate(ctx context.Context) (bool, error) {
+	return t.needsUpdate, nil
+}
+
+func (t *testCoordinator) Init(a *app.App) error { return nil }
+func (t *testCoordinator) Name() string          { return "testCoordinator" }
 
 type testSource struct {
 	conf Configuration

--- a/nodeconf/service_test.go
+++ b/nodeconf/service_test.go
@@ -68,7 +68,7 @@ func TestService_NetworkCompatibilityStatus(t *testing.T) {
 		defer fx.finish(t)
 		fx.run(t)
 		time.Sleep(time.Millisecond * 10)
-		assert.Equal(t, NetworkCompatibilityStatusError, fx.NetworkCompatibilityStatus())
+		assert.Equal(t, NetworkCompatibilityStatusOk, fx.NetworkCompatibilityStatus())
 	})
 }
 

--- a/nodeconf/source.go
+++ b/nodeconf/source.go
@@ -9,7 +9,6 @@ const CNameSource = "common.nodeconf.source"
 
 var (
 	ErrConfigurationNotChanged = errors.New("configuration not changed")
-	ErrNetworkNeedsUpdate      = errors.New("network needs update")
 )
 
 type Source interface {

--- a/nodeconf/source.go
+++ b/nodeconf/source.go
@@ -9,6 +9,7 @@ const CNameSource = "common.nodeconf.source"
 
 var (
 	ErrConfigurationNotChanged = errors.New("configuration not changed")
+	ErrNetworkNeedsUpdate      = errors.New("network needs update")
 )
 
 type Source interface {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3921/implement-logic-on-middleware-side-to-provide-flag-when-the-version-is