### PR TITLE
Remove unused .CreationTime

### DIFF
--- a/commonspace/spaceutils_test.go
+++ b/commonspace/spaceutils_test.go
@@ -67,10 +67,9 @@ func (m *mockConf) Init(a *app.App) (err error) {
 	m.id = networkId
 	m.networkId = networkId
 	m.configuration = nodeconf.Configuration{
-		Id:           networkId,
-		NetworkId:    networkId,
-		Nodes:        []nodeconf.Node{node},
-		CreationTime: time.Now(),
+		Id:        networkId,
+		NetworkId: networkId,
+		Nodes:     []nodeconf.Node{node},
 	}
 	return nil
 }
@@ -151,8 +150,7 @@ func (m *mockConf) NodeTypes(nodeId string) []nodeconf.NodeType {
 
 var _ nodeclient.NodeClient = (*mockNodeClient)(nil)
 
-type mockNodeClient struct {
-}
+type mockNodeClient struct{}
 
 func (m mockNodeClient) Init(a *app.App) (err error) {
 	return
@@ -170,8 +168,7 @@ func (m mockNodeClient) AclAddRecord(ctx context.Context, spaceId string, rec *c
 	return
 }
 
-type mockPeerManager struct {
-}
+type mockPeerManager struct{}
 
 func (p *mockPeerManager) BroadcastMessage(ctx context.Context, msg drpc.Message) error {
 	return nil
@@ -197,8 +194,7 @@ func (p *mockPeerManager) GetNodePeers(ctx context.Context) (peers []peer.Peer, 
 	return nil, nil
 }
 
-type testPeerManagerProvider struct {
-}
+type testPeerManagerProvider struct{}
 
 func (m *testPeerManagerProvider) Init(a *app.App) (err error) {
 	return nil
@@ -212,8 +208,7 @@ func (m *testPeerManagerProvider) NewPeerManager(ctx context.Context, spaceId st
 	return synctest.NewTestPeerManager(), nil
 }
 
-type mockPeerManagerProvider struct {
-}
+type mockPeerManagerProvider struct{}
 
 func (m *mockPeerManagerProvider) Init(a *app.App) (err error) {
 	return nil
@@ -227,8 +222,7 @@ func (m *mockPeerManagerProvider) NewPeerManager(ctx context.Context, spaceId st
 	return &mockPeerManager{}, nil
 }
 
-type mockPool struct {
-}
+type mockPool struct{}
 
 func (m *mockPool) Run(ctx context.Context) (err error) {
 	return nil
@@ -270,8 +264,7 @@ func (m *mockPool) Pick(ctx context.Context, id string) (peer.Peer, error) {
 	return nil, fmt.Errorf("no such peer")
 }
 
-type mockConfig struct {
-}
+type mockConfig struct{}
 
 func (m *mockConfig) Init(a *app.App) (err error) {
 	return nil
@@ -297,8 +290,7 @@ func (m *mockConfig) GetStreamConfig() streampool.StreamConfig {
 	}
 }
 
-type noOpSyncer struct {
-}
+type noOpSyncer struct{}
 
 func (n noOpSyncer) Init() {
 }
@@ -311,8 +303,7 @@ func (n noOpSyncer) Close() error {
 	return nil
 }
 
-type mockTreeSyncer struct {
-}
+type mockTreeSyncer struct{}
 
 func (m mockTreeSyncer) ShouldSync(peerId string) bool {
 	return false
@@ -471,8 +462,7 @@ func (t *testTreeManager) DeleteTree(ctx context.Context, spaceId, treeId string
 	return nil
 }
 
-type mockCoordinatorClient struct {
-}
+type mockCoordinatorClient struct{}
 
 func (m mockCoordinatorClient) StatusCheckMany(ctx context.Context, spaceIds []string) (statuses []*coordinatorproto.SpaceStatusPayload, limits *coordinatorproto.AccountLimits, err error) {
 	return
@@ -559,7 +549,7 @@ func (s *streamOpener) HandleMessage(peerCtx context.Context, peerId string, msg
 		return
 	}
 	if syncMsg.SpaceId() == "" {
-		var msg = &spacesyncproto.SpaceSubscription{}
+		msg := &spacesyncproto.SpaceSubscription{}
 		if err = msg.Unmarshal(syncMsg.Bytes); err != nil {
 			return
 		}
@@ -600,7 +590,7 @@ func (s *streamOpener) OpenStream(ctx context.Context, p peer.Peer) (stream drpc
 	if err != nil {
 		return
 	}
-	var msg = &spacesyncproto.SpaceSubscription{
+	msg := &spacesyncproto.SpaceSubscription{
 		SpaceIds: []string{s.spaceId},
 		Action:   spacesyncproto.SpaceSubscriptionAction_Subscribe,
 	}

--- a/coordinator/nodeconfsource/nodeconfsource.go
+++ b/coordinator/nodeconfsource/nodeconfsource.go
@@ -2,7 +2,6 @@ package nodeconfsource
 
 import (
 	"context"
-	"time"
 
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/coordinator/coordinatorclient"
@@ -68,9 +67,8 @@ func (n *nodeConfSource) GetLast(ctx context.Context, currentId string) (c nodec
 	}
 
 	return nodeconf.Configuration{
-		Id:           res.ConfigurationId,
-		NetworkId:    res.NetworkId,
-		Nodes:        nodes,
-		CreationTime: time.Unix(int64(res.CreationTimeUnix), 0),
+		Id:        res.ConfigurationId,
+		NetworkId: res.NetworkId,
+		Nodes:     nodes,
 	}, nil
 }

--- a/nodeconf/config.go
+++ b/nodeconf/config.go
@@ -2,7 +2,6 @@ package nodeconf
 
 import (
 	"errors"
-	"time"
 )
 
 type ConfigGetter interface {
@@ -13,9 +12,7 @@ type ConfigUpdateGetter interface {
 	GetNodeConfUpdateInterval() int
 }
 
-var (
-	ErrConfigurationNotFound = errors.New("node nodeConf not found")
-)
+var ErrConfigurationNotFound = errors.New("node nodeConf not found")
 
 type NodeType string
 
@@ -53,8 +50,7 @@ func (n Node) HasType(t NodeType) bool {
 }
 
 type Configuration struct {
-	Id           string    `yaml:"id"`
-	NetworkId    string    `yaml:"networkId"`
-	Nodes        []Node    `yaml:"nodes"`
-	CreationTime time.Time `yaml:"creationTime"`
+	Id        string `yaml:"id"`
+	NetworkId string `yaml:"networkId"`
+	Nodes     []Node `yaml:"nodes"`
 }

--- a/nodeconf/nodeconfstore/nodeconfstore.go
+++ b/nodeconf/nodeconfstore/nodeconfstore.go
@@ -2,12 +2,13 @@ package nodeconfstore
 
 import (
 	"context"
-	"github.com/anyproto/any-sync/app"
-	"github.com/anyproto/any-sync/nodeconf"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/anyproto/any-sync/app"
+	"github.com/anyproto/any-sync/nodeconf"
+	"gopkg.in/yaml.v3"
 )
 
 func New() NodeConfStore {
@@ -30,7 +31,7 @@ type configGetter interface {
 
 func (n *nodeConfStore) Init(a *app.App) (err error) {
 	n.path = a.MustComponent("config").(configGetter).GetNodeConfStorePath()
-	if e := os.Mkdir(n.path, 0755); e != nil && !os.IsExist(e) {
+	if e := os.MkdirAll(n.path, 0755); e != nil && !os.IsExist(e) {
 		return e
 	}
 	return

--- a/nodeconf/nodeconfstore/nodeconfstore_test.go
+++ b/nodeconf/nodeconfstore/nodeconfstore_test.go
@@ -2,14 +2,14 @@ package nodeconfstore
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/nodeconf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 var ctx = context.Background()
@@ -34,14 +34,11 @@ func TestNodeConfStore_GetLast(t *testing.T) {
 					Types:     []nodeconf.NodeType{nodeconf.NodeTypeTree, nodeconf.NodeTypeCoordinator},
 				},
 			},
-			CreationTime: time.Now().Round(time.Second),
 		}
 		require.NoError(t, fx.SaveLast(ctx, c))
 
 		res, err := fx.GetLast(ctx, "456")
 		require.NoError(t, err)
-		assert.Equal(t, c.CreationTime.Unix(), res.CreationTime.Unix())
-		c.CreationTime = res.CreationTime
 		assert.Equal(t, c, res)
 	})
 }

--- a/nodeconf/service_test.go
+++ b/nodeconf/service_test.go
@@ -213,7 +213,6 @@ func newTestConf() *testConf {
 					Types:     []NodeType{NodeTypeFile},
 				},
 			},
-			CreationTime: time.Now(),
 		},
 	}
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

I have read the CLA Document and I hereby sign the CLA.

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
Was created based on this comment - https://github.com/anyproto/tech-docs/issues/11#issuecomment-2337736894.
I have not found any use for this function in the code. But I'm not sure how much it needs to be deleted.
Since this is a public method. Now it looks like it's not playing any role.
I will be glad if you write why it was added.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [x] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?
Yes, if OK, we need to update docs with this changes.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
