### PR TITLE
Commonfile: refactor fileservice to allow use it as handler

### DIFF
--- a/commonfile/fileservice/filehandler.go
+++ b/commonfile/fileservice/filehandler.go
@@ -1,0 +1,93 @@
+package fileservice
+
+import (
+	"context"
+	"io"
+
+	"github.com/anyproto/any-sync/commonfile/fileblockstore"
+	chunker "github.com/ipfs/boxo/chunker"
+	"github.com/ipfs/boxo/ipld/merkledag"
+	"github.com/ipfs/boxo/ipld/unixfs/importer/balanced"
+	"github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
+	ufsio "github.com/ipfs/boxo/ipld/unixfs/io"
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/multiformats/go-multihash"
+	"go.uber.org/zap"
+)
+
+// FileHandler contains all the core file operations logic
+// It can be used directly with any BlockStore implementation
+type FileHandler struct {
+	bs        fileblockstore.BlockStore
+	dagService ipld.DAGService
+	prefix    cid.Prefix
+}
+
+// NewFileHandler creates a new FileHandler with the given BlockStore
+func NewFileHandler(bs fileblockstore.BlockStore) *FileHandler {
+	// Initialize CID prefix for version 1
+	v1CidPrefix := cid.Prefix{
+		Version:  1,
+		Codec:    cid.DagProtobuf,
+		MhType:   multihash.SHA2_256,
+		MhLength: -1,
+	}
+
+	return &FileHandler{
+		bs:         bs,
+		dagService: merkledag.NewDAGService(newBlockService(bs)),
+		prefix:     v1CidPrefix,
+	}
+}
+
+// AddFile adds file to ipfs storage
+func (fh *FileHandler) AddFile(ctx context.Context, r io.Reader) (ipld.Node, error) {
+	dbp := helpers.DagBuilderParams{
+		Dagserv:    fh.dagService,
+		Maxlinks:   helpers.DefaultLinksPerBlock,
+		CidBuilder: &fh.prefix,
+	}
+	dbh, err := dbp.New(chunker.NewSizeSplitter(r, ChunkSize))
+	if err != nil {
+		return nil, err
+	}
+	n, err := balanced.Layout(dbh)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("add file", zap.String("cid", n.Cid().String()))
+	return n, nil
+}
+
+// GetFile gets file from ipfs storage
+func (fh *FileHandler) GetFile(ctx context.Context, c cid.Cid) (ufsio.ReadSeekCloser, error) {
+	log.Debug("get file", zap.String("cid", c.String()))
+	n, err := fh.dagService.Get(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	return ufsio.NewDagReader(ctx, n, fh.dagService)
+}
+
+// HasCid checks if CID exists
+func (fh *FileHandler) HasCid(ctx context.Context, c cid.Cid) (exists bool, err error) {
+	if localBS, ok := fh.bs.(fileblockstore.BlockStoreLocal); ok {
+		res, err := localBS.ExistsCids(ctx, []cid.Cid{c})
+		if err != nil {
+			return false, err
+		}
+		return len(res) > 0, nil
+	}
+	// Fallback for non-local blockstores
+	_, err = fh.bs.Get(ctx, c)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// DAGService returns the underlying DAG service
+func (fh *FileHandler) DAGService() ipld.DAGService {
+	return fh.dagService
+}

--- a/commonfile/fileservice/fileservice.go
+++ b/commonfile/fileservice/fileservice.go
@@ -2,20 +2,14 @@ package fileservice
 
 import (
 	"context"
-	"fmt"
+	"io"
+
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/app/logger"
 	"github.com/anyproto/any-sync/commonfile/fileblockstore"
-	chunker "github.com/ipfs/boxo/chunker"
-	"github.com/ipfs/boxo/ipld/merkledag"
-	"github.com/ipfs/boxo/ipld/unixfs/importer/balanced"
-	"github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
 	ufsio "github.com/ipfs/boxo/ipld/unixfs/io"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
-	"github.com/multiformats/go-multihash"
-	"go.uber.org/zap"
-	"io"
 )
 
 const CName = "common.commonfile.fileservice"
@@ -41,68 +35,18 @@ type FileService interface {
 	HasCid(ctx context.Context, c cid.Cid) (exists bool, err error)
 	app.Component
 }
+
+// fileService is a thin wrapper for dependency injection
 type fileService struct {
-	bs        fileblockstore.BlockStoreLocal
-	merkledag ipld.DAGService
-	prefix    cid.Prefix
+	*FileHandler
 }
 
 func (fs *fileService) Init(a *app.App) (err error) {
-	prefix, err := merkledag.PrefixForCidVersion(1)
-	if err != nil {
-		return fmt.Errorf("bad CID Version: %s", err)
-	}
-	hashFunCode, ok := multihash.Names["sha2-256"]
-	if !ok {
-		return fmt.Errorf("unrecognized hash function")
-	}
-	prefix.MhType = hashFunCode
-	prefix.MhLength = -1
-	fs.bs = a.MustComponent(fileblockstore.CName).(fileblockstore.BlockStoreLocal)
-	fs.merkledag = merkledag.NewDAGService(newBlockService(fs.bs))
-	fs.prefix = prefix
-	return
+	bs := a.MustComponent(fileblockstore.CName).(fileblockstore.BlockStoreLocal)
+	fs.FileHandler = NewFileHandler(bs)
+	return nil
 }
 
 func (fs *fileService) Name() string {
 	return CName
-}
-
-func (fs *fileService) DAGService() ipld.DAGService {
-	return fs.merkledag
-}
-
-func (fs *fileService) AddFile(ctx context.Context, r io.Reader) (ipld.Node, error) {
-	dbp := helpers.DagBuilderParams{
-		Dagserv:    fs.merkledag,
-		Maxlinks:   helpers.DefaultLinksPerBlock,
-		CidBuilder: &fs.prefix,
-	}
-	dbh, err := dbp.New(chunker.NewSizeSplitter(r, ChunkSize))
-	if err != nil {
-		return nil, err
-	}
-	n, err := balanced.Layout(dbh)
-	if err != nil {
-		return nil, err
-	}
-	log.Debug("add file", zap.String("cid", n.Cid().String()))
-	return n, nil
-}
-
-func (fs *fileService) GetFile(ctx context.Context, c cid.Cid) (ufsio.ReadSeekCloser, error) {
-	log.Debug("get file", zap.String("cid", c.String()))
-	n, err := fs.merkledag.Get(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-	return ufsio.NewDagReader(ctx, n, fs.merkledag)
-}
-
-func (fs *fileService) HasCid(ctx context.Context, c cid.Cid) (exists bool, err error) {
-	res, err := fs.bs.ExistsCids(ctx, []cid.Cid{c})
-	if err != nil {
-		return
-	}
-	return len(res) > 0, nil
 }


### PR DESCRIPTION
Extract the code from the app component to a separate constructor so it can be used externally with a custom DagService