### PR TITLE
GO-6133 Fix panic on pool.Flush

### DIFF
--- a/net/pool/pool.go
+++ b/net/pool/pool.go
@@ -70,12 +70,18 @@ func (p *pool) get(ctx context.Context, source ocache.OCache, id string) (peer.P
 
 func (p *pool) Flush(ctx context.Context) error {
 	p.incoming.ForEach(func(v ocache.Object) (isContinue bool) {
-		pr := v.(peer.Peer)
+		pr, err := getPeer(v)
+		if err != nil {
+			return true
+		}
 		_, _ = p.incoming.Remove(ctx, pr.Id())
 		return true
 	})
 	p.outgoing.ForEach(func(v ocache.Object) (isContinue bool) {
-		pr := v.(peer.Peer)
+		pr, err := getPeer(v)
+		if err != nil {
+			return true
+		}
 		_, _ = p.outgoing.Remove(ctx, pr.Id())
 		return true
 	})


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6133/appsetdevicestate-panic-recovered-crash

We could store **pool.errObject** instead of **peer.Peer**, that's why we should use getPeer func to avoid panic