### PR TITLE
GO-7187 Decouple change encryption from ReadKey presence

### DIFF
--- a/commonspace/object/tree/objecttree/changebuilder.go
+++ b/commonspace/object/tree/objecttree/changebuilder.go
@@ -8,8 +8,18 @@ import (
 	"github.com/anyproto/any-sync/util/crypto"
 )
 
-var ErrEmptyChange = errors.New("change payload should not be empty")
+var (
+	ErrEmptyChange       = errors.New("change payload should not be empty")
+	ErrMissingEncryptKey = errors.New("encrypted change requires a read key")
+)
 
+// BuilderContent is the payload Build consumes to produce a signed change.
+//
+// Encryption contract: encryption is the default. Unencrypted is an explicit
+// opt-out - when false (the zero value), ReadKey MUST be non-nil and is used
+// to encrypt Content; Build returns ErrMissingEncryptKey otherwise (never
+// silently writes plaintext). When Unencrypted is true, Content is written
+// as-is regardless of ReadKey.
 type BuilderContent struct {
 	// TreeHeadsIds are current heads in the tree. They become PreviousIds in the new change
 	TreeHeadIds    []string
@@ -17,6 +27,7 @@ type BuilderContent struct {
 	SnapshotBaseId string
 	ReadKeyId      string
 	IsSnapshot     bool
+	Unencrypted    bool
 	PrivKey        crypto.PrivKey
 	ReadKey        crypto.SymKey
 	Content        []byte
@@ -228,15 +239,19 @@ func (c *changeBuilder) Build(payload BuilderContent) (ch *Change, rawIdChange *
 		IsSnapshot:     payload.IsSnapshot,
 		DataType:       payload.DataType,
 	}
-	if payload.ReadKey != nil {
+	if payload.Unencrypted {
+		change.ChangesData = payload.Content
+	} else {
+		if payload.ReadKey == nil {
+			err = ErrMissingEncryptKey
+			return
+		}
 		var encrypted []byte
 		encrypted, err = payload.ReadKey.Encrypt(payload.Content)
 		if err != nil {
 			return
 		}
 		change.ChangesData = encrypted
-	} else {
-		change.ChangesData = payload.Content
 	}
 	marshalledChange, err := change.MarshalVT()
 	if err != nil {

--- a/commonspace/object/tree/objecttree/changebuilder_test.go
+++ b/commonspace/object/tree/objecttree/changebuilder_test.go
@@ -1,0 +1,101 @@
+package objecttree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-sync/commonspace/object/accountdata"
+	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
+	"github.com/anyproto/any-sync/util/crypto"
+)
+
+// TestChangeBuilderBuild_EncryptionContract locks in the invariant that Build
+// gates encryption on BuilderContent.Unencrypted (inverted: zero value =
+// encrypted) rather than inferring it from ReadKey != nil. See Cure53
+// ATY-01-003 for context.
+func TestChangeBuilderBuild_EncryptionContract(t *testing.T) {
+	keys, err := accountdata.NewRandom()
+	require.NoError(t, err)
+
+	readKey, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+
+	basePayload := BuilderContent{
+		TreeHeadIds:    []string{"head"},
+		AclHeadId:      "aclHead",
+		SnapshotBaseId: "root",
+		PrivKey:        keys.SignKey,
+		Content:        []byte("secret payload"),
+		Timestamp:      1,
+	}
+
+	t.Run("encrypted (default) without read key fails loudly", func(t *testing.T) {
+		builder := NewChangeBuilder(newMockKeyStorage(), nil)
+		payload := basePayload
+		payload.Unencrypted = false
+		payload.ReadKey = nil
+
+		_, _, err := builder.Build(payload)
+		require.ErrorIs(t, err, ErrMissingEncryptKey)
+	})
+
+	t.Run("unencrypted opt-out writes content as-is", func(t *testing.T) {
+		builder := NewChangeBuilder(newMockKeyStorage(), nil)
+		payload := basePayload
+		payload.Unencrypted = true
+		payload.ReadKey = nil
+
+		ch, _, err := builder.Build(payload)
+		require.NoError(t, err)
+		require.Equal(t, payload.Content, ch.Data)
+	})
+
+	t.Run("encrypted (default) with read key produces ciphertext", func(t *testing.T) {
+		builder := NewChangeBuilder(newMockKeyStorage(), nil)
+		payload := basePayload
+		payload.Unencrypted = false
+		payload.ReadKey = readKey
+
+		ch, _, err := builder.Build(payload)
+		require.NoError(t, err)
+		require.NotEqual(t, payload.Content, ch.Data, "ciphertext must not equal plaintext")
+
+		decrypted, err := readKey.Decrypt(ch.Data)
+		require.NoError(t, err)
+		require.Equal(t, payload.Content, decrypted)
+	})
+}
+
+// TestChangeBuilderBuild_ReadKeyIgnoredWhenUnencrypted guarantees ReadKey
+// alone cannot flip the change into encrypted mode when Unencrypted is set -
+// the flag is the gate, not the key's presence.
+func TestChangeBuilderBuild_ReadKeyIgnoredWhenUnencrypted(t *testing.T) {
+	keys, err := accountdata.NewRandom()
+	require.NoError(t, err)
+	readKey, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+
+	builder := NewChangeBuilder(newMockKeyStorage(), nil)
+	payload := BuilderContent{
+		TreeHeadIds:    []string{"head"},
+		AclHeadId:      "aclHead",
+		SnapshotBaseId: "root",
+		PrivKey:        keys.SignKey,
+		Content:        []byte("plaintext"),
+		Timestamp:      1,
+		Unencrypted:    true,
+		ReadKey:        readKey,
+	}
+
+	ch, raw, err := builder.Build(payload)
+	require.NoError(t, err)
+	require.Equal(t, payload.Content, ch.Data)
+
+	// Round-trip: marshalled payload carries plaintext, not ciphertext.
+	rawTree := &treechangeproto.RawTreeChange{}
+	require.NoError(t, rawTree.UnmarshalVT(raw.RawChange))
+	treeCh := &treechangeproto.TreeChange{}
+	require.NoError(t, treeCh.UnmarshalVT(rawTree.Payload))
+	require.Equal(t, payload.Content, treeCh.ChangesData)
+}

--- a/commonspace/object/tree/objecttree/objecttree.go
+++ b/commonspace/object/tree/objecttree/objecttree.go
@@ -380,6 +380,7 @@ func (ot *objectTree) prepareBuilderContent(content SignableChangeContent) (cnt 
 		SnapshotBaseId: ot.tree.RootId(),
 		ReadKeyId:      readKeyId,
 		IsSnapshot:     content.IsSnapshot,
+		Unencrypted:    !content.ShouldBeEncrypted,
 		PrivKey:        content.Key,
 		ReadKey:        readKey,
 		Content:        content.Data,


### PR DESCRIPTION
Gate encryption in changeBuilder.Build on an explicit BuilderContent.Unencrypted flag rather than inferring it from ReadKey != nil, and make encryption the safe default (zero value encrypts; Unencrypted is an opt-out used by the settings object). Build now returns ErrMissingEncryptKey when encryption is expected but ReadKey is nil, instead of silently falling through to plaintext.

SignableChangeContent.ShouldBeEncrypted stays as-is to avoid churn for external callers; prepareBuilderContent translates it into Unencrypted.

Addresses Cure53 ATY-01-003.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
