### PR TITLE
GO-7188 Migrate from deprecated go-cid constants to go-multicodec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/mr-tron/base58 v1.3.0
 	github.com/multiformats/go-multibase v0.3.0
+	github.com/multiformats/go-multicodec v0.10.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/planetscale/vtprotobuf v0.6.0
 	github.com/prometheus/client_golang v1.23.2
@@ -88,7 +89,6 @@ require (
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr v0.16.1 // indirect
-	github.com/multiformats/go-multicodec v0.10.0 // indirect
 	github.com/multiformats/go-multistream v0.6.1 // indirect
 	github.com/multiformats/go-varint v0.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/util/cidutil/cid.go
+++ b/util/cidutil/cid.go
@@ -2,6 +2,7 @@ package cidutil
 
 import (
 	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multicodec"
 	mh "github.com/multiformats/go-multihash"
 )
 
@@ -10,7 +11,7 @@ func NewCidFromBytes(data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return cid.NewCidV1(cid.DagCBOR, hash).String(), nil
+	return cid.NewCidV1(uint64(multicodec.DagCbor), hash).String(), nil
 }
 
 func VerifyCid(data []byte, id string) bool {
@@ -18,5 +19,5 @@ func VerifyCid(data []byte, id string) bool {
 	if err != nil {
 		return false
 	}
-	return cid.NewCidV1(cid.DagCBOR, hash).String() == id
+	return cid.NewCidV1(uint64(multicodec.DagCbor), hash).String() == id
 }


### PR DESCRIPTION
Replace cid.DagCBOR (deprecated per go-cid#137) with multicodec.DagCbor in util/cidutil. Promote go-multicodec from indirect to direct dep. Values are identical (0x71), so CID output is byte-identical.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
