### PR TITLE
GO-6500 validate ed25519 public key is on curve in UnmarshalEd25519Pu…

### DIFF
--- a/util/crypto/ed25519.go
+++ b/util/crypto/ed25519.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"sync"
 
+	"filippo.io/edwards25519"
 	"github.com/anyproto/any-sync/util/crypto/cryptoproto"
 	"github.com/anyproto/any-sync/util/strkey"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -242,9 +243,14 @@ func (k *Ed25519PubKey) LibP2P() (crypto.PubKey, error) {
 }
 
 // UnmarshalEd25519PublicKey returns a public key from input bytes.
+// It validates that the bytes decode as a valid point on the Edwards curve,
+// rejecting malformed or non-curve inputs at the earliest boundary.
 func UnmarshalEd25519PublicKey(data []byte) (PubKey, error) {
 	if len(data) != 32 {
 		return nil, errors.New("expect ed25519 public key data size to be 32")
+	}
+	if _, err := (&edwards25519.Point{}).SetBytes(data); err != nil {
+		return nil, fmt.Errorf("invalid ed25519 public key: %w", err)
 	}
 
 	return NewEd25519PubKey(data), nil

--- a/util/crypto/ed25519_test.go
+++ b/util/crypto/ed25519_test.go
@@ -54,6 +54,33 @@ func TestEd25519PublicKeyToCurve25519(t *testing.T) {
 
 }
 
+func TestUnmarshalEd25519PublicKey(t *testing.T) {
+	t.Run("valid key", func(t *testing.T) {
+		pub, _, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		_, err = UnmarshalEd25519PublicKey(pub)
+		require.NoError(t, err)
+	})
+	t.Run("wrong length", func(t *testing.T) {
+		_, err := UnmarshalEd25519PublicKey([]byte{1, 2, 3})
+		require.Error(t, err)
+	})
+	t.Run("32 bytes not on curve", func(t *testing.T) {
+		// 32 bytes that pass length check but do not decode as a valid
+		// Edwards curve point. Same pattern used by TestEd25519PublicKeyToCurve25519.
+		badPoint := []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}
+		_, err := UnmarshalEd25519PublicKey(badPoint)
+		require.Error(t, err)
+	})
+	t.Run("proto wrapper rejects non-curve point", func(t *testing.T) {
+		badPoint := []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}
+		proto, err := NewEd25519PubKey(badPoint).Marshall()
+		require.NoError(t, err)
+		_, err = UnmarshalEd25519PublicKeyProto(proto)
+		require.Error(t, err)
+	})
+}
+
 func Test_InvalidKey(t *testing.T) {
 	corruptedKey := []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}
 	t.Run("decrypt", func(t *testing.T) {


### PR DESCRIPTION
…blicKey

Reject bytes that pass the length check but do not decode as a valid Edwards curve point, at the earliest unmarshal boundary. Covers UnmarshalEd25519PublicKeyProto via delegation.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
