### PR TITLE
GO-6607: anchor acceptor verification to the network root key

### DIFF
--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/anyproto/any-sync/nodeconf"
 	"github.com/anyproto/any-sync/nodeconf/mock_nodeconf"
 	"github.com/anyproto/any-sync/testutil/accounttest"
+	"github.com/anyproto/any-sync/util/crypto"
+	"github.com/anyproto/any-sync/util/strkey"
 )
 
 var ctx = context.Background()
@@ -221,12 +223,19 @@ func newFixture(t *testing.T) *fixture {
 	fx.consCl.EXPECT().Run(gomock.Any()).AnyTimes()
 	fx.consCl.EXPECT().Close(gomock.Any()).AnyTimes()
 
+	_, netPub, err := crypto.GenerateRandomEd25519KeyPair()
+	require.NoError(t, err)
+	netPubRaw, err := netPub.Raw()
+	require.NoError(t, err)
+	networkId, err := strkey.Encode(strkey.NetworkAddressVersionByte, netPubRaw)
+	require.NoError(t, err)
+
 	nc := mock_nodeconf.NewMockService(ctrl)
 	nc.EXPECT().Name().Return(nodeconf.CName).AnyTimes()
 	nc.EXPECT().Init(gomock.Any()).AnyTimes()
 	nc.EXPECT().Run(gomock.Any()).AnyTimes()
 	nc.EXPECT().Close(gomock.Any()).AnyTimes()
-	nc.EXPECT().ConsensusPeers().Return(nil).AnyTimes()
+	nc.EXPECT().Configuration().Return(nodeconf.Configuration{NetworkId: networkId}).AnyTimes()
 
 	fx.a.Register(fx.consCl).Register(fx.AclService).Register(&accounttest.AccountTestService{}).Register(nc)
 

--- a/acl/object.go
+++ b/acl/object.go
@@ -61,12 +61,16 @@ func (a *aclObject) AddConsensusRecords(recs []*consensusproto.RawRecordWithId) 
 		if a.store, a.consErr = list.NewInMemoryStorage(a.id, recs); a.consErr != nil {
 			return
 		}
-		netKey, err := crypto.DecodeNetworkId(a.aclService.nodeConf.Configuration().NetworkId)
-		if err != nil {
-			a.consErr = fmt.Errorf("invalid networkId: %w", err)
-			return
+		verifier := recordverifier.AcceptorVerifier(recordverifier.NewValidateFull())
+		if networkId := a.aclService.nodeConf.Configuration().NetworkId; networkId != "" {
+			netKey, err := crypto.DecodeNetworkId(networkId)
+			if err != nil {
+				a.consErr = fmt.Errorf("invalid networkId: %w", err)
+				return
+			}
+			verifier = recordverifier.New(netKey)
 		}
-		if a.AclList, a.consErr = list.BuildAclListWithIdentity(a.aclService.accountService.Account(), a.store, recordverifier.New(netKey)); a.consErr != nil {
+		if a.AclList, a.consErr = list.BuildAclListWithIdentity(a.aclService.accountService.Account(), a.store, verifier); a.consErr != nil {
 			return
 		}
 	} else {

--- a/acl/object.go
+++ b/acl/object.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/object/acl/list"
 	"github.com/anyproto/any-sync/commonspace/object/acl/recordverifier"
 	"github.com/anyproto/any-sync/consensus/consensusproto"
+	"github.com/anyproto/any-sync/util/crypto"
 )
 
 func (as *aclService) newAclObject(ctx context.Context, id string) (*aclObject, error) {
@@ -59,7 +61,12 @@ func (a *aclObject) AddConsensusRecords(recs []*consensusproto.RawRecordWithId) 
 		if a.store, a.consErr = list.NewInMemoryStorage(a.id, recs); a.consErr != nil {
 			return
 		}
-		if a.AclList, a.consErr = list.BuildAclListWithIdentity(a.aclService.accountService.Account(), a.store, recordverifier.New(a.aclService.nodeConf)); a.consErr != nil {
+		netKey, err := crypto.DecodeNetworkId(a.aclService.nodeConf.Configuration().NetworkId)
+		if err != nil {
+			a.consErr = fmt.Errorf("invalid networkId: %w", err)
+			return
+		}
+		if a.AclList, a.consErr = list.BuildAclListWithIdentity(a.aclService.accountService.Account(), a.store, recordverifier.New(netKey)); a.consErr != nil {
 			return
 		}
 	} else {

--- a/commonspace/acl/aclclient/acjoiningclient.go
+++ b/commonspace/acl/aclclient/acjoiningclient.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anyproto/any-sync/consensus/consensusproto"
 	"github.com/anyproto/any-sync/node/nodeclient"
 	"github.com/anyproto/any-sync/nodeconf"
+	"github.com/anyproto/any-sync/util/crypto"
 )
 
 const CName = "common.acl.aclclient"
@@ -65,7 +66,11 @@ func (c *aclJoiningClient) getAcl(ctx context.Context, spaceId string) (l list.A
 	if err != nil {
 		return
 	}
-	return list.BuildAclListWithIdentity(c.keys, storage, recordverifier.New(c.nodeConf))
+	netKey, err := crypto.DecodeNetworkId(c.nodeConf.Configuration().NetworkId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid networkId: %w", err)
+	}
+	return list.BuildAclListWithIdentity(c.keys, storage, recordverifier.New(netKey))
 }
 
 func (c *aclJoiningClient) CancelJoin(ctx context.Context, spaceId string) (err error) {

--- a/commonspace/acl/aclclient/acjoiningclient.go
+++ b/commonspace/acl/aclclient/acjoiningclient.go
@@ -66,11 +66,15 @@ func (c *aclJoiningClient) getAcl(ctx context.Context, spaceId string) (l list.A
 	if err != nil {
 		return
 	}
-	netKey, err := crypto.DecodeNetworkId(c.nodeConf.Configuration().NetworkId)
-	if err != nil {
-		return nil, fmt.Errorf("invalid networkId: %w", err)
+	verifier := recordverifier.AcceptorVerifier(recordverifier.NewValidateFull())
+	if networkId := c.nodeConf.Configuration().NetworkId; networkId != "" {
+		netKey, decodeErr := crypto.DecodeNetworkId(networkId)
+		if decodeErr != nil {
+			return nil, fmt.Errorf("invalid networkId: %w", decodeErr)
+		}
+		verifier = recordverifier.New(netKey)
 	}
-	return list.BuildAclListWithIdentity(c.keys, storage, recordverifier.New(netKey))
+	return list.BuildAclListWithIdentity(c.keys, storage, verifier)
 }
 
 func (c *aclJoiningClient) CancelJoin(ctx context.Context, spaceId string) (err error) {

--- a/commonspace/acl/aclwaiter/aclwaiter.go
+++ b/commonspace/acl/aclwaiter/aclwaiter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/object/acl/list"
 	"github.com/anyproto/any-sync/commonspace/object/acl/recordverifier"
 	"github.com/anyproto/any-sync/nodeconf"
+	"github.com/anyproto/any-sync/util/crypto"
 	"github.com/anyproto/any-sync/util/periodicsync"
 )
 
@@ -86,7 +87,11 @@ func (a *aclWaiter) loop(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		acl, err := list.BuildAclListWithIdentity(a.keys, storage, recordverifier.New(a.nodeConf))
+		netKey, err := crypto.DecodeNetworkId(a.nodeConf.Configuration().NetworkId)
+		if err != nil {
+			return fmt.Errorf("invalid networkId: %w", err)
+		}
+		acl, err := list.BuildAclListWithIdentity(a.keys, storage, recordverifier.New(netKey))
 		if err != nil {
 			return err
 		}

--- a/commonspace/acl/aclwaiter/aclwaiter.go
+++ b/commonspace/acl/aclwaiter/aclwaiter.go
@@ -87,11 +87,15 @@ func (a *aclWaiter) loop(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		netKey, err := crypto.DecodeNetworkId(a.nodeConf.Configuration().NetworkId)
-		if err != nil {
-			return fmt.Errorf("invalid networkId: %w", err)
+		verifier := recordverifier.AcceptorVerifier(recordverifier.NewValidateFull())
+		if networkId := a.nodeConf.Configuration().NetworkId; networkId != "" {
+			netKey, decodeErr := crypto.DecodeNetworkId(networkId)
+			if decodeErr != nil {
+				return fmt.Errorf("invalid networkId: %w", decodeErr)
+			}
+			verifier = recordverifier.New(netKey)
 		}
-		acl, err := list.BuildAclListWithIdentity(a.keys, storage, recordverifier.New(netKey))
+		acl, err := list.BuildAclListWithIdentity(a.keys, storage, verifier)
 		if err != nil {
 			return err
 		}

--- a/commonspace/object/acl/list/list_test.go
+++ b/commonspace/object/acl/list/list_test.go
@@ -40,9 +40,13 @@ func createStore(ctx context.Context, t *testing.T) anystore.DB {
 
 var mockMetadata = []byte("very important metadata")
 
-type noConsensusPeers struct{}
-
-func (noConsensusPeers) ConsensusPeers() []string { return nil }
+// testNetworkKey returns a fresh random pubkey for tests that need a
+// recordverifier without caring which key it trusts.
+func testNetworkKey(t *testing.T) crypto.PubKey {
+	_, pub, err := crypto.GenerateRandomEd25519KeyPair()
+	require.NoError(t, err)
+	return pub
+}
 
 func newFixture(t *testing.T) *aclFixture {
 	ownerKeys, err := accountdata.NewRandom()
@@ -318,8 +322,9 @@ func TestAclList_MetadataDecrypt(t *testing.T) {
 func TestAclList_ValidateUsesCorrectVerifier(t *testing.T) {
 	fx := newFixture(t)
 	var ownerAcl = fx.ownerAcl
-	ownerAcl.aclState.contentValidator.(*contentValidator).verifier = recordverifier.New(noConsensusPeers{})
-	ownerAcl.verifier = recordverifier.New(noConsensusPeers{})
+	netKey := testNetworkKey(t)
+	ownerAcl.aclState.contentValidator.(*contentValidator).verifier = recordverifier.New(netKey)
+	ownerAcl.verifier = recordverifier.New(netKey)
 	// building invite
 	inv, err := ownerAcl.RecordBuilder().BuildInvite()
 	require.NoError(t, err)

--- a/commonspace/object/acl/recordverifier/recordverifier.go
+++ b/commonspace/object/acl/recordverifier/recordverifier.go
@@ -2,7 +2,6 @@ package recordverifier
 
 import (
 	"fmt"
-	"slices"
 
 	"github.com/anyproto/any-sync/consensus/consensusproto"
 	"github.com/anyproto/any-sync/util/crypto"
@@ -15,27 +14,21 @@ type AcceptorVerifier interface {
 
 type RecordVerifier = AcceptorVerifier
 
-// ConsensusPeersSource is the minimal view of nodeconf needed by the verifier.
-// nodeconf.NodeConf satisfies this interface; tests can supply a trivial fake.
-type ConsensusPeersSource interface {
-	ConsensusPeers() []string
-}
-
 // New returns a RecordVerifier that accepts only records whose AcceptorIdentity
-// resolves to a peerId listed by src.ConsensusPeers(). Records signed by any
-// other key — even with a well-formed Ed25519 signature — are rejected. The
-// consensus node is assumed to use the same Ed25519 key for its peer identity
-// and record acceptance (see any-sync-consensusnode/account/service.go).
-func New(src ConsensusPeersSource) RecordVerifier {
+// equals networkKey — the Ed25519 root key of the network (the pubkey encoded
+// by nodeconf.Configuration().NetworkId; decode via crypto.DecodeNetworkId).
+// Records signed by any other key — even with a well-formed Ed25519 signature —
+// are rejected.
+func New(networkKey crypto.PubKey) RecordVerifier {
 	return &recordVerifier{
-		store: crypto.NewKeyStorage(),
-		src:   src,
+		store:      crypto.NewKeyStorage(),
+		networkKey: networkKey,
 	}
 }
 
 type recordVerifier struct {
-	store crypto.KeyStorage
-	src   ConsensusPeersSource
+	store      crypto.KeyStorage
+	networkKey crypto.PubKey
 }
 
 func (r *recordVerifier) VerifyAcceptor(rec *consensusproto.RawRecord) (err error) {
@@ -46,9 +39,8 @@ func (r *recordVerifier) VerifyAcceptor(rec *consensusproto.RawRecord) (err erro
 			return fmt.Errorf("failed to get acceptor identity: %w", err)
 		}
 	}
-	peerId := identity.PeerId()
-	if !slices.Contains(r.src.ConsensusPeers(), peerId) {
-		return fmt.Errorf("acceptor %s is not a consensus node", peerId)
+	if r.networkKey == nil || !identity.Equals(r.networkKey) {
+		return fmt.Errorf("acceptor %s is not the network key", identity.Network())
 	}
 	verified, err := identity.Verify(rec.Payload, rec.AcceptorSignature)
 	if !verified || err != nil {

--- a/commonspace/object/acl/recordverifier/recordverifier_test.go
+++ b/commonspace/object/acl/recordverifier/recordverifier_test.go
@@ -10,12 +10,6 @@ import (
 	"github.com/anyproto/any-sync/util/crypto"
 )
 
-type fakeConsensusPeers struct {
-	peers []string
-}
-
-func (f fakeConsensusPeers) ConsensusPeers() []string { return f.peers }
-
 type fixture struct {
 	*recordVerifier
 	networkPrivKey crypto.PrivKey
@@ -25,8 +19,7 @@ func newFixture(t *testing.T) *fixture {
 	accService := &accounttest.AccountTestService{}
 	require.NoError(t, accService.Init(nil))
 	networkKey := accService.Account().SignKey
-	src := fakeConsensusPeers{peers: []string{networkKey.GetPublic().PeerId()}}
-	verifier := New(src).(*recordVerifier)
+	verifier := New(networkKey.GetPublic()).(*recordVerifier)
 	return &fixture{
 		recordVerifier: verifier,
 		networkPrivKey: networkKey,
@@ -107,7 +100,7 @@ func TestRecordVerifier_VerifyAcceptor_EmptySignature(t *testing.T) {
 }
 
 // An acceptor signature may be cryptographically valid, but if the signer's
-// peerId is not in ConsensusPeers() the record must be rejected. This is the
+// pubkey is not the network key the record must be rejected. This is the
 // Cure53 finding the verifier was hardened against.
 func TestRecordVerifier_VerifyAcceptor_UnknownAcceptor(t *testing.T) {
 	fx := newFixture(t)
@@ -125,5 +118,5 @@ func TestRecordVerifier_VerifyAcceptor_UnknownAcceptor(t *testing.T) {
 	}
 	err = fx.VerifyAcceptor(rawRecord)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not a consensus node")
+	require.Contains(t, err.Error(), "not the network key")
 }

--- a/commonspace/spaceservice.go
+++ b/commonspace/spaceservice.go
@@ -4,6 +4,7 @@ package commonspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -110,6 +111,21 @@ func (s *spaceService) Name() (name string) {
 	return CName
 }
 
+// buildRecordVerifier returns a verifier anchored to the network root key.
+// When NetworkId is empty (e.g. LocalOnly mode) no consensus signatures will
+// ever arrive, so we fall back to the no-op ValidateFull verifier.
+func (s *spaceService) buildRecordVerifier() (recordverifier.RecordVerifier, error) {
+	networkId := s.configurationService.Configuration().NetworkId
+	if networkId == "" {
+		return recordverifier.NewValidateFull(), nil
+	}
+	netKey, err := crypto.DecodeNetworkId(networkId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid networkId: %w", err)
+	}
+	return recordverifier.New(netKey), nil
+}
+
 func (s *spaceService) CreateSpace(ctx context.Context, payload spacepayloads.SpaceCreatePayload) (id string, err error) {
 	// TODO: switch to SpaceCreatePayloadV1 after next proto update
 	// storageCreate, err := spacepayloads.StoragePayloadForSpaceCreateV1(payload)
@@ -211,7 +227,10 @@ func (s *spaceService) NewSpace(ctx context.Context, id string, deps Deps) (Spac
 	if deps.Indexer != nil {
 		keyValueIndexer = deps.Indexer
 	}
-	recordVerifier := recordverifier.New(s.configurationService)
+	recordVerifier, err := s.buildRecordVerifier()
+	if err != nil {
+		return nil, err
+	}
 	if deps.recordVerifier != nil {
 		recordVerifier = deps.recordVerifier
 	}
@@ -348,7 +367,11 @@ func (s *spaceService) spacePullWithPeer(ctx context.Context, p peer.Peer, id st
 		if err != nil {
 			return nil, err
 		}
-		recordVerifier := recordverifier.New(s.configurationService)
+		netKey, err := crypto.DecodeNetworkId(s.configurationService.Configuration().NetworkId)
+		if err != nil {
+			return nil, fmt.Errorf("invalid networkId: %w", err)
+		}
+		recordVerifier := recordverifier.New(netKey)
 		if deps.recordVerifier != nil {
 			recordVerifier = deps.recordVerifier
 		}


### PR DESCRIPTION
The first cut of this finding cross-checked rec.AcceptorIdentity against nodeconf.ConsensusPeers(). That works in dev (peerKey == signingKey in the local consensusnode YAML) but not in production: prod's network config contains no entries of type=consensus, and consensus nodes there sign with a SigningKey that is the network root key while their PeerKey is unrelated. The check therefore rejected every legitimate ACL record on prod and broke sync network-wide.

Switch the anchor to the network root pubkey, which nodeconf already publishes as Configuration().NetworkId (strkey-encoded Ed25519 pubkey, decodable via crypto.DecodeNetworkId). VerifyAcceptor now compares identity.Equals(networkKey).

recordverifier.New takes the decoded *crypto.PubKey directly, so callers own the decode. Each call site decodes lazily at use-time rather than at Init, so component registration order doesn't matter and LocalOnly mode (empty NetworkId) doesn't fail the app at startup. spaceservice falls back to recordverifier.NewValidateFull when NetworkId is empty since LocalOnly spaces never receive acceptor-signed records.

Confirmed against the prod consensus mongo: every AcceptorIdentity ever written (160,297 records across 56,622 logs since 2024-01-16) decodes to prod's NetworkId, so legitimate history will pass the new check.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
