### PR TITLE
GO-6473 Restrict Admin role transitions to owner-only in ACL validator

### DIFF
--- a/commonspace/object/acl/list/acltestsuite_test.go
+++ b/commonspace/object/acl/list/acltestsuite_test.go
@@ -80,9 +80,12 @@ func TestAclExecutor(t *testing.T) {
 		{"e.revoke::invId", ErrNoSuchRecord},
 		// e can't remove a, because a is the owner
 		{"e.remove::a", ErrInsufficientPermissions},
-		// e can add new users
-		{"e.add::x,r,m1;y,adm,m2", nil},
-		// now y can also change permission as an admin
+		// e (admin) can add new non-admin users
+		{"e.add::x,r,m1", nil},
+		// only the owner can introduce another admin
+		{"e.add::y,adm,m2", ErrInsufficientPermissions},
+		{"a.add::y,adm,m2", nil},
+		// y (admin) can change permission of a non-admin
 		{"y.changes::x,rw", nil},
 		// e can generate another invite
 		{"e.invite::inv1Id", nil},

--- a/commonspace/object/acl/list/list_test.go
+++ b/commonspace/object/acl/list/list_test.go
@@ -503,3 +503,68 @@ func TestAclPermissions_IsAdmin(t *testing.T) {
 	require.False(t, AclPermissionsGuest.IsAdmin())
 	require.False(t, AclPermissionsNone.IsAdmin())
 }
+
+// FR1: only the owner can grant the Admin role.
+func TestAclList_AdminCannotGrantAdmin(t *testing.T) {
+	a := NewAclExecutor("spaceId")
+	cmds := []struct {
+		cmd string
+		err error
+	}{
+		{"a.init::a", nil},
+		{"a.invite::invId", nil},
+		{"b.join::invId", nil},
+		{"a.approve::b,r", nil},
+		{"e.join::invId", nil},
+		{"a.approve::e,adm", nil},
+		// e is admin; cannot grant admin to b
+		{"e.changes::b,adm", ErrInsufficientPermissions},
+	}
+	for _, c := range cmds {
+		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
+	}
+}
+
+// FR2: only the owner can revoke the Admin role.
+func TestAclList_AdminCannotRevokeAdmin(t *testing.T) {
+	a := NewAclExecutor("spaceId")
+	cmds := []struct {
+		cmd string
+		err error
+	}{
+		{"a.init::a", nil},
+		{"a.invite::invId", nil},
+		{"e.join::invId", nil},
+		{"a.approve::e,adm", nil},
+		{"y.join::invId", nil},
+		{"a.approve::y,adm", nil},
+		// e is admin; cannot demote y from admin
+		{"e.changes::y,rw", ErrInsufficientPermissions},
+		// owner can demote
+		{"a.changes::y,rw", nil},
+	}
+	for _, c := range cmds {
+		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
+	}
+}
+
+// Owner can grant and revoke Admin freely.
+func TestAclList_OwnerCanGrantAndRevokeAdmin(t *testing.T) {
+	a := NewAclExecutor("spaceId")
+	cmds := []struct {
+		cmd string
+		err error
+	}{
+		{"a.init::a", nil},
+		{"a.invite::invId", nil},
+		{"b.join::invId", nil},
+		{"a.approve::b,r", nil},
+		// owner promotes b to admin
+		{"a.changes::b,adm", nil},
+		// owner demotes b back to writer
+		{"a.changes::b,rw", nil},
+	}
+	for _, c := range cmds {
+		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
+	}
+}

--- a/commonspace/object/acl/list/list_test.go
+++ b/commonspace/object/acl/list/list_test.go
@@ -568,3 +568,30 @@ func TestAclList_OwnerCanGrantAndRevokeAdmin(t *testing.T) {
 		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
 	}
 }
+
+// FR2: only the owner can remove an Admin (revoking via account removal).
+func TestAclList_AdminCannotRemoveAdmin(t *testing.T) {
+	a := NewAclExecutor("spaceId")
+	cmds := []struct {
+		cmd string
+		err error
+	}{
+		{"a.init::a", nil},
+		{"a.invite::invId", nil},
+		{"e.join::invId", nil},
+		{"a.approve::e,adm", nil},
+		{"y.join::invId", nil},
+		{"a.approve::y,adm", nil},
+		{"b.join::invId", nil},
+		{"a.approve::b,rw", nil},
+		// e (admin) can remove a regular writer
+		{"e.remove::b", nil},
+		// e (admin) cannot remove another admin
+		{"e.remove::y", ErrInsufficientPermissions},
+		// owner can remove the admin
+		{"a.remove::y", nil},
+	}
+	for _, c := range cmds {
+		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
+	}
+}

--- a/commonspace/object/acl/list/list_test.go
+++ b/commonspace/object/acl/list/list_test.go
@@ -494,3 +494,12 @@ func TestAclState_OwnerPubKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, fx.ownerKeys.SignKey.GetPublic().Account(), pubKey.Account())
 }
+
+func TestAclPermissions_IsAdmin(t *testing.T) {
+	require.True(t, AclPermissionsAdmin.IsAdmin())
+	require.False(t, AclPermissionsOwner.IsAdmin())
+	require.False(t, AclPermissionsWriter.IsAdmin())
+	require.False(t, AclPermissionsReader.IsAdmin())
+	require.False(t, AclPermissionsGuest.IsAdmin())
+	require.False(t, AclPermissionsNone.IsAdmin())
+}

--- a/commonspace/object/acl/list/list_test.go
+++ b/commonspace/object/acl/list/list_test.go
@@ -569,6 +569,77 @@ func TestAclList_OwnerCanGrantAndRevokeAdmin(t *testing.T) {
 	}
 }
 
+// FR1: only the owner can introduce a new Admin via AccountsAdd.
+func TestAclList_AdminCannotAddNewAdmin(t *testing.T) {
+	a := NewAclExecutor("spaceId")
+	cmds := []struct {
+		cmd string
+		err error
+	}{
+		{"a.init::a", nil},
+		{"a.invite::invId", nil},
+		{"e.join::invId", nil},
+		{"a.approve::e,adm", nil},
+		// e (admin) can add a writer
+		{"e.add::x,rw,m1", nil},
+		// e (admin) cannot add an admin
+		{"e.add::z,adm,m2", ErrInsufficientPermissions},
+		// owner can
+		{"a.add::z,adm,m2", nil},
+	}
+	for _, c := range cmds {
+		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
+	}
+}
+
+// FR1: only the owner can issue or change an invite that grants Admin.
+func TestAclList_AdminCannotIssueAdminInvite(t *testing.T) {
+	a := NewAclExecutor("spaceId")
+	cmds := []struct {
+		cmd string
+		err error
+	}{
+		{"a.init::a", nil},
+		{"a.invite::invId", nil},
+		{"e.join::invId", nil},
+		{"a.approve::e,adm", nil},
+		// e (admin) cannot create an anyone-can-join invite at Admin level
+		{"e.invite_anyone::admInv,a", ErrInsufficientPermissions},
+		// owner can
+		{"a.invite_anyone::admInv,a", nil},
+		// e (admin) cannot change an existing invite to Admin level
+		{"a.invite_anyone::otherInv,rw", nil},
+		{"e.invite_change::otherInv,a", ErrInsufficientPermissions},
+		// owner can
+		{"a.invite_change::otherInv,a", nil},
+	}
+	for _, c := range cmds {
+		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
+	}
+}
+
+// FR1: only the owner can accept a join request at Admin level.
+func TestAclList_AdminCannotApproveAsAdmin(t *testing.T) {
+	a := NewAclExecutor("spaceId")
+	cmds := []struct {
+		cmd string
+		err error
+	}{
+		{"a.init::a", nil},
+		{"a.invite::invId", nil},
+		{"e.join::invId", nil},
+		{"a.approve::e,adm", nil},
+		{"b.join::invId", nil},
+		// e (admin) cannot approve b as admin
+		{"e.approve::b,adm", ErrInsufficientPermissions},
+		// owner can
+		{"a.approve::b,adm", nil},
+	}
+	for _, c := range cmds {
+		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
+	}
+}
+
 // FR2: only the owner can remove an Admin (revoking via account removal).
 func TestAclList_AdminCannotRemoveAdmin(t *testing.T) {
 	a := NewAclExecutor("spaceId")

--- a/commonspace/object/acl/list/models.go
+++ b/commonspace/object/acl/list/models.go
@@ -99,6 +99,10 @@ func (p AclPermissions) IsGuest() bool {
 	return aclrecordproto.AclUserPermissions(p) == aclrecordproto.AclUserPermissions_Guest
 }
 
+func (p AclPermissions) IsAdmin() bool {
+	return aclrecordproto.AclUserPermissions(p) == aclrecordproto.AclUserPermissions_Admin
+}
+
 func (p AclPermissions) CanWrite() bool {
 	switch aclrecordproto.AclUserPermissions(p) {
 	case aclrecordproto.AclUserPermissions_Admin:

--- a/commonspace/object/acl/list/validator.go
+++ b/commonspace/object/acl/list/validator.go
@@ -210,7 +210,8 @@ func (c *contentValidator) ValidatePermissionChange(ch *aclrecordproto.AclAccoun
 	if !c.verifier.ShouldValidate() {
 		return nil
 	}
-	if !c.aclState.Permissions(authorIdentity).CanManageAccounts() {
+	authorPerms := c.aclState.Permissions(authorIdentity)
+	if !authorPerms.CanManageAccounts() {
 		return ErrInsufficientPermissions
 	}
 	chIdentity, err := c.keyStore.PubKeyFromProto(ch.Identity)
@@ -233,9 +234,19 @@ func (c *contentValidator) ValidatePermissionChange(ch *aclrecordproto.AclAccoun
 		return ErrInsufficientPermissions
 	}
 
+	if currentState.Permissions.IsAdmin() && !authorPerms.IsOwner() {
+		// only the owner can revoke the Admin role from a user (FR2)
+		return ErrInsufficientPermissions
+	}
+
 	if ch.Permissions == aclrecordproto.AclUserPermissions_Owner {
 		// not supported
 		// if we are going to support owner transfer, it should be done with a separate acl change so we can't have more than 1 owner at a time
+		return ErrInsufficientPermissions
+	}
+
+	if ch.Permissions == aclrecordproto.AclUserPermissions_Admin && !authorPerms.IsOwner() {
+		// only the owner can assign the Admin role (FR1)
 		return ErrInsufficientPermissions
 	}
 

--- a/commonspace/object/acl/list/validator.go
+++ b/commonspace/object/acl/list/validator.go
@@ -87,7 +87,8 @@ func (c *contentValidator) ValidateAccountsAdd(ch *aclrecordproto.AclAccountsAdd
 	if !c.verifier.ShouldValidate() {
 		return nil
 	}
-	if !c.aclState.Permissions(authorIdentity).CanManageAccounts() {
+	authorPerms := c.aclState.Permissions(authorIdentity)
+	if !authorPerms.CanManageAccounts() {
 		return ErrInsufficientPermissions
 	}
 	for _, ch := range ch.Additions {
@@ -103,6 +104,10 @@ func (c *contentValidator) ValidateAccountsAdd(ch *aclrecordproto.AclAccountsAdd
 			return ErrIsOwner
 		}
 		if perm.NoPermissions() {
+			return ErrInsufficientPermissions
+		}
+		if perm.IsAdmin() && !authorPerms.IsOwner() {
+			// only the owner can add an account at Admin level (FR1)
 			return ErrInsufficientPermissions
 		}
 	}
@@ -263,12 +268,17 @@ func (c *contentValidator) ValidateInvite(ch *aclrecordproto.AclAccountInvite, a
 	if !c.verifier.ShouldValidate() {
 		return nil
 	}
-	if !c.aclState.Permissions(authorIdentity).CanManageAccounts() {
+	authorPerms := c.aclState.Permissions(authorIdentity)
+	if !authorPerms.CanManageAccounts() {
 		return ErrInsufficientPermissions
 	}
 	permissions := AclPermissions(ch.Permissions)
 	if ch.InviteType == aclrecordproto.AclInviteType_AnyoneCanJoin {
 		if permissions.IsOwner() || permissions.NoPermissions() || permissions.IsGuest() {
+			return ErrInsufficientPermissions
+		}
+		if permissions.IsAdmin() && !authorPerms.IsOwner() {
+			// only the owner can issue an Admin-granting invite (FR1)
 			return ErrInsufficientPermissions
 		}
 		if ch.EncryptedReadKey == nil {
@@ -283,7 +293,8 @@ func (c *contentValidator) ValidateInviteChange(ch *aclrecordproto.AclAccountInv
 	if !c.verifier.ShouldValidate() {
 		return nil
 	}
-	if !c.aclState.Permissions(authorIdentity).CanManageAccounts() {
+	authorPerms := c.aclState.Permissions(authorIdentity)
+	if !authorPerms.CanManageAccounts() {
 		return ErrInsufficientPermissions
 	}
 	invite, exists := c.aclState.invites[ch.InviteRecordId]
@@ -298,6 +309,10 @@ func (c *contentValidator) ValidateInviteChange(ch *aclrecordproto.AclAccountInv
 		return ErrInsufficientPermissions
 	}
 	if permissions.IsOwner() || permissions.NoPermissions() || permissions.IsGuest() {
+		return ErrInsufficientPermissions
+	}
+	if permissions.IsAdmin() && !authorPerms.IsOwner() {
+		// only the owner can change invite permissions to Admin (FR1)
 		return ErrInsufficientPermissions
 	}
 	return
@@ -362,7 +377,8 @@ func (c *contentValidator) ValidateRequestAccept(ch *aclrecordproto.AclAccountRe
 	if !c.verifier.ShouldValidate() {
 		return nil
 	}
-	if !c.aclState.Permissions(authorIdentity).CanManageAccounts() {
+	authorPerms := c.aclState.Permissions(authorIdentity)
+	if !authorPerms.CanManageAccounts() {
 		return ErrInsufficientPermissions
 	}
 	record, exists := c.aclState.requestRecords[ch.RequestRecordId]
@@ -377,6 +393,10 @@ func (c *contentValidator) ValidateRequestAccept(ch *aclrecordproto.AclAccountRe
 		return ErrIncorrectIdentity
 	}
 	if ch.Permissions == aclrecordproto.AclUserPermissions_Owner {
+		return ErrInsufficientPermissions
+	}
+	if ch.Permissions == aclrecordproto.AclUserPermissions_Admin && !authorPerms.IsOwner() {
+		// only the owner can approve a join request at Admin level (FR1)
 		return ErrInsufficientPermissions
 	}
 	return

--- a/commonspace/object/acl/list/validator.go
+++ b/commonspace/object/acl/list/validator.go
@@ -414,7 +414,8 @@ func (c *contentValidator) ValidateAccountRemove(ch *aclrecordproto.AclAccountRe
 	if !c.verifier.ShouldValidate() {
 		return nil
 	}
-	if !c.aclState.Permissions(authorIdentity).CanManageAccounts() {
+	authorPerms := c.aclState.Permissions(authorIdentity)
+	if !authorPerms.CanManageAccounts() {
 		return ErrInsufficientPermissions
 	}
 	seenIdentities := map[string]struct{}{}
@@ -431,6 +432,10 @@ func (c *contentValidator) ValidateAccountRemove(ch *aclrecordproto.AclAccountRe
 			return ErrNoSuchAccount
 		}
 		if permissions.IsOwner() {
+			return ErrInsufficientPermissions
+		}
+		if permissions.IsAdmin() && !authorPerms.IsOwner() {
+			// only the owner can remove an Admin (FR2 — revoking admin via removal)
 			return ErrInsufficientPermissions
 		}
 		idKey := mapKeyFromPubKey(identity)

--- a/commonspace/settings/settingsobject_test.go
+++ b/commonspace/settings/settingsobject_test.go
@@ -352,6 +352,56 @@ func TestSettingsObject_DeleteObject_Restricted_AuthorCanDelete(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSettingsObject_DeleteObject_Restricted_AdminCanDelete(t *testing.T) {
+	fx := newSettingsFixture(t)
+	defer fx.stop(t)
+	fx.init(t)
+
+	delId := "delId"
+	DoSnapshot = func(len int) bool {
+		return false
+	}
+
+	// Build a DeleteRestricted ACL where "c" is admin (CanManageAccounts() == true).
+	aclSetup := newValidatorTestSetup(t, true)
+	aclState := aclSetup.acl.AclState()
+	adminKeys := aclSetup.executor.ActualAccounts()["c"].Keys
+
+	fx.syncTree.EXPECT().Id().Return("syncId")
+	fx.syncTree.EXPECT().Len().Return(10)
+	// Single GetEntry call: the author-check branch is skipped for admins.
+	fx.headStorage.EXPECT().GetEntry(gomock.Any(), delId).Return(headstorage.HeadsEntry{
+		Id:        delId,
+		IsDerived: false,
+	}, nil)
+	fx.headStorage.EXPECT().GetEntriesByParentId(gomock.Any(), delId).Return(nil, nil)
+
+	// ACL permission check: admin "c" has CanManageAccounts() == true,
+	// so needsAuthorCheck stays false and objectAuthor is never consulted.
+	fx.syncTree.EXPECT().AclList().Return(fx.aclList)
+	fx.aclList.EXPECT().RLock()
+	fx.aclList.EXPECT().AclState().Return(aclState).AnyTimes()
+	fx.aclList.EXPECT().RUnlock()
+	fx.account.EXPECT().Account().Return(adminKeys)
+
+	// Proceed straight to creating the change — no TreeStorage / Root lookup.
+	res := []byte("settingsData")
+	fx.doc.state = &settingsstate.State{LastIteratedId: "someId"}
+	fx.changeFactory.EXPECT().CreateObjectDeleteChange([]string{delId}, fx.doc.state, false).Return(res, nil)
+	fx.account.EXPECT().Account().Return(adminKeys)
+	fx.syncTree.EXPECT().AddContent(gomock.Any(), objecttree.SignableChangeContent{
+		Data:              res,
+		Key:               adminKeys.SignKey,
+		IsSnapshot:        false,
+		ShouldBeEncrypted: false,
+	}).Return(objecttree.AddResult{}, nil)
+	fx.stateBuilder.EXPECT().Build(fx.doc, fx.doc.state).Return(fx.doc.state, nil)
+	fx.deletionManager.EXPECT().UpdateState(gomock.Any(), fx.doc.state).Return(nil)
+
+	err := fx.doc.DeleteObject(ctx, delId)
+	require.NoError(t, err)
+}
+
 func TestSettingsObject_DeleteObject_Restricted_NonAuthorCannotDelete(t *testing.T) {
 	fx := newSettingsFixture(t)
 	defer fx.stop(t)


### PR DESCRIPTION
## Summary

Tighten the ACL validator so the `Admin` permission can only be granted, revoked, or removed by the space `Owner`. Previously any author with `CanManageAccounts()` (Owner *or* Admin) could perform these operations, allowing admins to escalate other members. This PR aligns the validator with the product requirement that **only owners control admin membership**.

Validator changes (`commonspace/object/acl/list/validator.go`):
- `ValidatePermissionChange`: granting `Admin` or revoking from a current `Admin` requires Owner.
- `ValidateAccountRemove`: removing an `Admin` member requires Owner.
- `ValidateAccountsAdd`: adding a new account at `Admin` level requires Owner.
- `ValidateInvite` / `ValidateInviteChange`: creating or repointing an invite at `Admin` level requires Owner.
- `ValidateRequestAccept`: approving a join request at `Admin` level requires Owner.

Helper (`commonspace/object/acl/list/models.go`):
- New `AclPermissions.IsAdmin()` for clarity at call sites.

## Test plan

- [x] New unit tests cover each restriction:
  - `TestAclList_AdminCannotGrantAdmin`
  - `TestAclList_AdminCannotRevokeAdmin`
  - `TestAclList_OwnerCanGrantAndRevokeAdmin`
  - `TestAclList_AdminCannotRemoveAdmin`
  - `TestAclList_AdminCannotAddNewAdmin`
  - `TestAclList_AdminCannotIssueAdminInvite`
  - `TestAclList_AdminCannotApproveAsAdmin`
  - `TestAclPermissions_IsAdmin`
- [x] Existing `TestAclExecutor` updated to keep Admin-introducing operations under the owner.
- [x] New `TestSettingsObject_DeleteObject_Restricted_AdminCanDelete` confirms admins still pass the per-tree `DeleteRestricted` gate (`CanManageAccounts()`), unchanged.
- [x] Full any-sync test suite passes (`go test ./...`).

## Companion PR

The downstream consumer in anytype-heart depends on these validator changes. See companion PR in `anytype-heart` (link in comments after creation).