### PR TITLE
fix race in Ed25519PrivKey.GetPublic

### DIFF
--- a/util/crypto/ed25519.go
+++ b/util/crypto/ed25519.go
@@ -119,8 +119,7 @@ func (k *Ed25519PrivKey) Equals(o Key) bool {
 // GetPublic returns an ed25519 public key from a private key.
 func (k *Ed25519PrivKey) GetPublic() PubKey {
 	return &Ed25519PubKey{
-		pubKey:   k.pubKeyBytes(),
-		pubCurve: k.pubCurve,
+		pubKey: k.pubKeyBytes(),
 	}
 }
 


### PR DESCRIPTION
GetPublic copied k.pubCurve into the returned Ed25519PubKey without synchronization, while Decrypt populates k.pubCurve inside k.once.Do. Concurrent GetPublic + Decrypt on the same key (e.g. secureservice handshake racing ACL load on space init) tripped the race detector.

The copied field was dead: Ed25519PubKey.Encrypt always recomputes pubCurve via its own curveOnce.Do, overwriting whatever was passed in. Dropping the copy removes the race at zero behavioral cost.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
