### PR TITLE
Do not hand out dead QUIC connections from the pool

### DIFF
--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -89,6 +89,12 @@ type OCache interface {
 	Add(id string, value Object) (err error)
 	// Remove closes and removes object
 	Remove(ctx context.Context, id string) (ok bool, err error)
+	// RemoveSame closes and removes the object only if the value currently
+	// stored under id is exactly the given one (pointer identity). It lets a
+	// caller evict a specific instance it owns without racing a newer value
+	// that has replaced it under the same id. Returns ok=true only when this
+	// call performed the removal.
+	RemoveSame(ctx context.Context, id string, value Object) (ok bool, err error)
 	// TryRemove Tries to close and to remove the object
 	TryRemove(id string) (ok bool, err error)
 	// ForEach iterates over all loaded objects, breaks when callback returns false
@@ -212,6 +218,26 @@ func (c *oCache) remove(ctx context.Context, e *entry) (ok bool, err error) {
 		c.mu.Unlock()
 	}
 	return
+}
+
+func (c *oCache) RemoveSame(ctx context.Context, id string, value Object) (ok bool, err error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return false, ErrClosed
+	}
+	e, exists := c.data[id]
+	// e.value is written only under c.mu (in Add/load), so reading it here is
+	// race-free. remove() acts on this exact entry: it deletes/closes it only
+	// if this call is the one that transitions it to closing. If e was already
+	// replaced under the same id it is in a closed state and remove() is a
+	// no-op, so a stale caller can never close the newer value that took the id.
+	same := exists && e.value == value
+	c.mu.Unlock()
+	if !same {
+		return false, ErrNotExists
+	}
+	return c.remove(ctx, e)
 }
 
 func (c *oCache) TryRemove(id string) (ok bool, err error) {

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -593,3 +593,50 @@ func TestOCacheFuzzy(t *testing.T) {
 		require.Equal(t, 0, c.Len())
 	})
 }
+
+func TestOCache_RemoveSame(t *testing.T) {
+	newCache := func() OCache {
+		return New(func(ctx context.Context, id string) (Object, error) {
+			return nil, ErrNotExists
+		})
+	}
+
+	t.Run("removes matching value", func(t *testing.T) {
+		c := newCache()
+		obj := NewTestObject("1", false, nil)
+		require.NoError(t, c.Add("1", obj))
+		ok, err := c.RemoveSame(ctx, "1", obj)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, obj.closeCalled)
+		require.Equal(t, 0, c.Len())
+	})
+
+	t.Run("keeps replacement under same id", func(t *testing.T) {
+		c := newCache()
+		old := NewTestObject("old", false, nil)
+		repl := NewTestObject("repl", false, nil)
+		require.NoError(t, c.Add("1", old))
+		// old gets replaced by repl under the same id
+		_, err := c.Remove(ctx, "1")
+		require.NoError(t, err)
+		require.NoError(t, c.Add("1", repl))
+		// a stale RemoveSame holding the old value must not touch repl
+		ok, err := c.RemoveSame(ctx, "1", old)
+		require.ErrorIs(t, err, ErrNotExists)
+		require.False(t, ok)
+		require.False(t, repl.closeCalled, "replacement must not be closed")
+		require.Equal(t, 1, c.Len())
+		pk, err := c.Pick(ctx, "1")
+		require.NoError(t, err)
+		require.Equal(t, repl, pk)
+	})
+
+	t.Run("missing id", func(t *testing.T) {
+		c := newCache()
+		obj := NewTestObject("1", false, nil)
+		ok, err := c.RemoveSame(ctx, "1", obj)
+		require.ErrorIs(t, err, ErrNotExists)
+		require.False(t, ok)
+	})
+}

--- a/commonspace/headsync/diffsyncer.go
+++ b/commonspace/headsync/diffsyncer.go
@@ -3,9 +3,8 @@ package headsync
 import (
 	"context"
 	"errors"
+	"net"
 	"time"
-
-	"github.com/quic-go/quic-go"
 
 	"github.com/anyproto/any-sync/commonspace/headsync/headstorage"
 	"github.com/anyproto/any-sync/commonspace/object/keyvalue/kvinterfaces"
@@ -100,8 +99,10 @@ func (d *diffSyncer) Sync(ctx context.Context) error {
 	d.log.DebugCtx(ctx, "start diffsync", zap.Strings("peerIds", peerIds))
 	for _, p := range peers {
 		if err = d.syncWithPeer(peer.CtxWithPeerAddr(ctx, p.Id()), p); err != nil {
-			var idleTimeoutErr *quic.IdleTimeoutError
-			if !errors.As(err, &idleTimeoutErr) && !errors.Is(err, context.DeadlineExceeded) {
+			// suppress benign transient failures: a closed/idle connection
+			// (normalized to transport.ErrConnClosed, which unwraps to
+			// net.ErrClosed) or a sync deadline
+			if !errors.Is(err, net.ErrClosed) && !errors.Is(err, context.DeadlineExceeded) {
 				d.log.ErrorCtx(ctx, "can't sync with peer", zap.String("peer", p.Id()), zap.Error(err))
 			}
 		}

--- a/net/peer/peer.go
+++ b/net/peer/peer.go
@@ -130,6 +130,9 @@ func (p *peer) Id() string {
 }
 
 func (p *peer) AcquireDrpcConn(ctx context.Context) (drpc.Conn, error) {
+	if p.IsClosed() {
+		return nil, transport.ErrConnClosed
+	}
 	p.mu.Lock()
 	if len(p.inactive) == 0 {
 		wait := p.limiter.wait(len(p.active) + int(p.openingWaitCount.Load()))

--- a/net/peer/peer_test.go
+++ b/net/peer/peer_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	_ "net/http/pprof"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 
 	"github.com/anyproto/any-sync/net/rpc"
 	"github.com/anyproto/any-sync/net/secureservice/handshake"
+	"github.com/anyproto/any-sync/net/transport"
 	"github.com/anyproto/any-sync/net/transport/mock_transport"
 )
 
@@ -306,6 +308,7 @@ func newFixture(t *testing.T, peerId string) *fixture {
 		return ac.conn, ac.err
 	}).AnyTimes()
 	fx.mc.EXPECT().Close().AnyTimes()
+	fx.mc.EXPECT().IsClosed().DoAndReturn(func() bool { return fx.mcClosed.Load() }).AnyTimes()
 	p, err := NewPeer(fx.mc, fx.testCtrl)
 	require.NoError(t, err)
 	fx.peer = p.(*peer)
@@ -318,11 +321,23 @@ type fixture struct {
 	mc       *mock_transport.MockMultiConn
 	acceptCh chan acceptedConn
 	testCtrl *testCtrl
+	mcClosed atomic.Bool
 }
 
 func (fx *fixture) finish() {
 	fx.testCtrl.close()
 	fx.ctrl.Finish()
+}
+
+func TestPeer_AcquireDrpcConn_ConnClosed(t *testing.T) {
+	fx := newFixture(t, "p1")
+	defer fx.finish()
+
+	fx.mcClosed.Store(true) // underlying MultiConn is dead
+
+	dc, err := fx.AcquireDrpcConn(context.Background())
+	assert.ErrorIs(t, err, transport.ErrConnClosed)
+	assert.Nil(t, dc)
 }
 
 func newTesCtrl() *testCtrl {

--- a/net/pool/pool.go
+++ b/net/pool/pool.go
@@ -34,13 +34,32 @@ type poolStats struct {
 }
 
 type pool struct {
-	outgoing    ocache.OCache
-	incoming    ocache.OCache
-	statService debugstat.StatService
+	outgoing      ocache.OCache
+	incoming      ocache.OCache
+	statService   debugstat.StatService
+	closingCtx    context.Context
+	closingCancel context.CancelFunc
 }
 
 func (p *pool) Name() (name string) {
 	return CName
+}
+
+// evictOnClose removes the peer from the cache as soon as its underlying
+// connection dies, instead of waiting for the next Get or the GC to notice.
+// When the whole pool is shutting down, cache.Close already evicts every peer,
+// so per-peer removal is skipped. It never outlives the peer.
+func (p *pool) evictOnClose(pr peer.Peer, cache ocache.OCache) {
+	select {
+	case <-pr.CloseChan():
+	case <-p.closingCtx.Done():
+		return
+	}
+	if p.closingCtx.Err() != nil {
+		// pool is shutting down; let cache.Close handle eviction
+		return
+	}
+	_, _ = cache.Remove(p.closingCtx, pr.Id())
 }
 
 func (p *pool) Get(ctx context.Context, id string) (pr peer.Peer, err error) {
@@ -145,19 +164,19 @@ func (p *pool) GetOneOf(ctx context.Context, peerIds []string) (peer.Peer, error
 }
 
 func (p *pool) AddPeer(ctx context.Context, pr peer.Peer) (err error) {
-	if err = p.incoming.Add(pr.Id(), pr); err != nil {
-		if err == ocache.ErrExists {
-			// in case when an incoming connection with a peer already exists, we close and remove an existing connection
-			if v, e := p.incoming.Pick(ctx, pr.Id()); e == nil {
-				_ = v.Close()
-				_, _ = p.incoming.Remove(ctx, pr.Id())
-				return p.incoming.Add(pr.Id(), pr)
-			}
-		} else {
-			return err
+	err = p.incoming.Add(pr.Id(), pr)
+	if err == ocache.ErrExists {
+		// in case when an incoming connection with a peer already exists, we close and remove an existing connection
+		if v, e := p.incoming.Pick(ctx, pr.Id()); e == nil {
+			_ = v.Close()
+			_, _ = p.incoming.Remove(ctx, pr.Id())
+			err = p.incoming.Add(pr.Id(), pr)
 		}
 	}
-	return
+	if err == nil {
+		go p.evictOnClose(pr, p.incoming)
+	}
+	return err
 }
 
 func (p *pool) Pick(ctx context.Context, id string) (pr peer.Peer, err error) {

--- a/net/pool/pool.go
+++ b/net/pool/pool.go
@@ -59,7 +59,10 @@ func (p *pool) evictOnClose(pr peer.Peer, cache ocache.OCache) {
 		// pool is shutting down; let cache.Close handle eviction
 		return
 	}
-	_, _ = cache.Remove(p.closingCtx, pr.Id())
+	// Remove only if the cache still holds THIS peer. A newer connection for
+	// the same id may have replaced pr (incoming AddPeer re-add, or outgoing
+	// redial); removing by id alone would close that live replacement.
+	_, _ = cache.RemoveSame(p.closingCtx, pr.Id(), pr)
 }
 
 func (p *pool) Get(ctx context.Context, id string) (pr peer.Peer, err error) {

--- a/net/pool/pool_test.go
+++ b/net/pool/pool_test.go
@@ -707,3 +707,67 @@ func (t *testPeer) IsClosed() bool {
 func (t *testPeer) CloseChan() <-chan struct{} {
 	return t.closed
 }
+
+func TestPool_EvictsOutgoingOnClose(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.Finish()
+
+	tp := newTestPeer("1")
+	fx.Dialer.dial = func(ctx context.Context, peerId string) (peer.Peer, error) {
+		return tp, nil
+	}
+
+	p, err := fx.Get(ctx, "1")
+	require.NoError(t, err)
+	require.Equal(t, tp, p)
+
+	// simulate the underlying connection dying
+	require.NoError(t, tp.Close())
+
+	require.Eventually(t, func() bool {
+		return fx.Service.(*poolService).outgoing.Len() == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestPool_EvictsIncomingOnClose(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.Finish()
+
+	tp := newTestPeer("inc1")
+	require.NoError(t, fx.AddPeer(ctx, tp))
+
+	require.NoError(t, tp.Close())
+
+	require.Eventually(t, func() bool {
+		return fx.Service.(*poolService).incoming.Len() == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestPool_EvictOnClose_ExitsOnShutdownWithoutEviction(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.Finish()
+	p := fx.Service.(*poolService).pool
+
+	tp := newTestPeer("inc1") // peer stays alive (CloseChan never fires)
+	done := make(chan struct{})
+	go func() {
+		p.evictOnClose(tp, p.incoming)
+		close(done)
+	}()
+
+	// peer alive and pool not closing: watcher must stay blocked
+	select {
+	case <-done:
+		t.Fatal("watcher exited before peer close or shutdown")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// pool shutting down: watcher must exit promptly and NOT touch the peer
+	p.closingCancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not exit on shutdown")
+	}
+	require.False(t, tp.IsClosed(), "shutdown path must not close/evict the peer")
+}

--- a/net/pool/pool_test.go
+++ b/net/pool/pool_test.go
@@ -748,7 +748,10 @@ func TestPool_EvictOnClose_ExitsOnShutdownWithoutEviction(t *testing.T) {
 	defer fx.Finish()
 	p := fx.Service.(*poolService).pool
 
+	// the peer is actually in the cache, so a wrong eviction would be observable
 	tp := newTestPeer("inc1") // peer stays alive (CloseChan never fires)
+	require.NoError(t, p.incoming.Add(tp.Id(), tp))
+
 	done := make(chan struct{})
 	go func() {
 		p.evictOnClose(tp, p.incoming)
@@ -762,12 +765,40 @@ func TestPool_EvictOnClose_ExitsOnShutdownWithoutEviction(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	// pool shutting down: watcher must exit promptly and NOT touch the peer
+	// pool shutting down: watcher must exit promptly and must NOT evict the peer
 	p.closingCancel()
 	select {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("watcher did not exit on shutdown")
 	}
-	require.False(t, tp.IsClosed(), "shutdown path must not close/evict the peer")
+	require.False(t, tp.IsClosed(), "shutdown path must not close the peer")
+	pk, err := p.incoming.Pick(ctx, tp.Id())
+	require.NoError(t, err, "shutdown path must leave the peer for cache.Close to evict")
+	require.Equal(t, tp, pk)
+}
+
+// TestPool_ReAddIncomingKeepsReplacement guards against the stale-watcher race:
+// when a second incoming connection replaces an existing one under the same id,
+// the watcher spawned for the old (now closed) peer must NOT evict the live
+// replacement.
+func TestPool_ReAddIncomingKeepsReplacement(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.Finish()
+
+	old := newTestPeer("1")
+	require.NoError(t, fx.AddPeer(ctx, old))
+
+	// a fresh incoming connection for the same id: AddPeer closes `old`
+	// (waking its watcher) and installs `repl` under the same id.
+	repl := newTestPeer("1")
+	require.NoError(t, fx.AddPeer(ctx, repl))
+	require.True(t, old.IsClosed(), "re-add must close the old connection")
+
+	// the old peer's watcher must never tear down the live replacement
+	require.Never(t, func() bool {
+		pk, err := fx.Pick(ctx, "1")
+		return err != nil || pk != peer.Peer(repl)
+	}, 300*time.Millisecond, 10*time.Millisecond)
+	require.False(t, repl.IsClosed(), "replacement must stay open")
 }

--- a/net/pool/poolservice.go
+++ b/net/pool/poolservice.go
@@ -47,17 +47,23 @@ type poolService struct {
 func (p *poolService) Init(a *app.App) (err error) {
 	p.dialer = a.MustComponent("net.peerservice").(dialer)
 	p.pool = &pool{}
+	p.pool.closingCtx, p.pool.closingCancel = context.WithCancel(context.Background())
 	if m := a.Component(metric.CName); m != nil {
 		p.metricReg = m.(metric.Metric).Registry()
 	}
 	p.pool.outgoing = ocache.New(
 		func(ctx context.Context, id string) (value ocache.Object, err error) {
-			if value, err = p.dialer.Dial(ctx, id); err != nil {
+			value, err = p.dialer.Dial(ctx, id)
+			if err != nil {
 				if errors.Is(err, handshake.ErrIncompatibleVersion) {
 					return &errObject{err: err, createdTime: atomic.NewTime(time.Now())}, nil
 				}
+				return value, err
 			}
-			return
+			if pr, ok := value.(peer.Peer); ok {
+				go p.pool.evictOnClose(pr, p.pool.outgoing)
+			}
+			return value, nil
 		},
 		ocache.WithLogger(log.Sugar()),
 		ocache.WithGCPeriod(time.Minute/2),
@@ -87,6 +93,9 @@ func (p *pool) Run(ctx context.Context) (err error) {
 }
 
 func (p *pool) Close(ctx context.Context) (err error) {
+	if p.closingCancel != nil {
+		p.closingCancel()
+	}
 	p.statService.RemoveProvider(p)
 	if e := p.incoming.Close(); e != nil {
 		log.Warn("close incoming cache error", zap.Error(e))

--- a/net/transport/quic/conn.go
+++ b/net/transport/quic/conn.go
@@ -48,12 +48,28 @@ func (q *quicMultiConn) Context() context.Context {
 	return q.cctx
 }
 
+// isConnDead reports whether err means the underlying QUIC connection is gone
+// (idle timeout, peer-initiated close, or an already-closed connection), as
+// opposed to a transient or stream-level error.
+func isConnDead(err error) bool {
+	if err == nil {
+		return false
+	}
+	var idle *quic.IdleTimeoutError
+	if errors.As(err, &idle) {
+		return true
+	}
+	var appErr *quic.ApplicationError
+	if errors.As(err, &appErr) && appErr.ErrorCode == 2 {
+		return true
+	}
+	return errors.Is(err, quic.ErrServerClosed) || errors.Is(err, net.ErrClosed)
+}
+
 func (q *quicMultiConn) Accept() (conn net.Conn, err error) {
 	stream, err := q.connection.AcceptStream(context.Background())
 	if err != nil {
-		if errors.Is(err, quic.ErrServerClosed) {
-			err = transport.ErrConnClosed
-		} else if aerr, ok := err.(*quic.ApplicationError); ok && aerr.ErrorCode == 2 {
+		if isConnDead(err) {
 			err = transport.ErrConnClosed
 		}
 		return nil, err
@@ -69,6 +85,9 @@ func (q *quicMultiConn) Accept() (conn net.Conn, err error) {
 func (q *quicMultiConn) Open(ctx context.Context) (conn net.Conn, err error) {
 	stream, err := q.OpenStreamSync(ctx)
 	if err != nil {
+		if isConnDead(err) {
+			return nil, transport.ErrConnClosed
+		}
 		return nil, err
 	}
 	return quicNetConn{

--- a/net/transport/quic/conn_idle_test.go
+++ b/net/transport/quic/conn_idle_test.go
@@ -1,0 +1,48 @@
+package quic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/anyproto/any-sync/net/transport"
+	"github.com/anyproto/any-sync/net/transport/quic/mock_quic"
+)
+
+func TestQuicMultiConn_Open_IdleTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConn := mock_quic.NewMockconnection(ctrl)
+	q := &quicMultiConn{
+		cctx:         context.Background(),
+		connection:   mockConn,
+		writeTimeout: time.Second,
+		closeTimeout: 100 * time.Millisecond,
+	}
+	mockConn.EXPECT().OpenStreamSync(gomock.Any()).Return(nil, &quic.IdleTimeoutError{})
+
+	_, err := q.Open(context.Background())
+	assert.ErrorIs(t, err, transport.ErrConnClosed)
+}
+
+func TestQuicMultiConn_Accept_IdleTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConn := mock_quic.NewMockconnection(ctrl)
+	q := &quicMultiConn{
+		cctx:         context.Background(),
+		connection:   mockConn,
+		writeTimeout: time.Second,
+		closeTimeout: 100 * time.Millisecond,
+	}
+	mockConn.EXPECT().AcceptStream(gomock.Any()).Return(nil, &quic.IdleTimeoutError{})
+
+	_, err := q.Accept()
+	assert.ErrorIs(t, err, transport.ErrConnClosed)
+}

--- a/net/transport/transport.go
+++ b/net/transport/transport.go
@@ -3,13 +3,23 @@ package transport
 
 import (
 	"context"
-	"errors"
 	"net"
 )
 
 var (
-	ErrConnClosed = errors.New("connection closed")
+	// ErrConnClosed is returned by transport Open/Accept when the underlying
+	// connection is gone (idle timeout, peer close, server close). It unwraps to
+	// net.ErrClosed so callers can match either sentinel.
+	ErrConnClosed error = connClosedError{}
 )
+
+// connClosedError carries a distinctive message (to tell it apart from other
+// connection errors in logs) while unwrapping to net.ErrClosed.
+type connClosedError struct{}
+
+func (connClosedError) Error() string { return "transport connection closed" }
+
+func (connClosedError) Unwrap() error { return net.ErrClosed }
 
 const (
 	Yamux        = "yamux"

--- a/net/transport/transport_test.go
+++ b/net/transport/transport_test.go
@@ -1,0 +1,17 @@
+package transport
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrConnClosed(t *testing.T) {
+	// must unwrap to net.ErrClosed so the quic idle-timeout normalization keeps
+	// errors.Is(err, net.ErrClosed) detectors working across the boundary
+	assert.True(t, errors.Is(ErrConnClosed, net.ErrClosed))
+	// distinctive text so it can be told apart from other connection errors in logs
+	assert.Equal(t, "transport connection closed", ErrConnClosed.Error())
+}


### PR DESCRIPTION
## Problem
A pooled QUIC connection that silently died (sleep / NAT rebind / network change) was still handed out, surfacing `timeout: no recent network activity` (quic-go `IdleTimeoutError`) on the next RPC. Root cause: subConn liveness was not subordinate to the parent `MultiConn`.

## Changes
- **net/transport/quic**: map idle-timeout / closed-conn errors to `transport.ErrConnClosed` in `Open` and `Accept` (was leaking the raw quic error).
- **net/peer**: `AcquireDrpcConn` refuses to return a sub-connection when the underlying `MultiConn` is closed.
- **net/pool**: evict a peer from the cache as soon as its connection closes (one watcher per `MultiConn`), instead of waiting for the next `Get`/GC; watcher skips removal during pool shutdown.

## Tests
Unit tests for each, incl. `-race`: quic `Open`/`Accept` mapping, `AcquireDrpcConn` on a closed conn, eager pool eviction + shutdown skip.