### PR TITLE
test(peerservice): expect MultiConn.CloseChan in mockMC

### DIFF
--- a/net/peerservice/peerservice_test.go
+++ b/net/peerservice/peerservice_test.go
@@ -207,6 +207,9 @@ func (fx *fixture) mockMC(peerId string) *mock_transport.MockMultiConn {
 	mc.EXPECT().Context().Return(cctx).AnyTimes()
 	mc.EXPECT().Accept().Return(nil, fmt.Errorf("test")).AnyTimes()
 	mc.EXPECT().Close().AnyTimes()
+	// the pool subscribes to CloseChan to evict the peer when the connection
+	// dies; keep the peer alive by returning a nil channel that never fires.
+	mc.EXPECT().CloseChan().Return((<-chan struct{})(nil)).AnyTimes()
 	return mc
 }
 


### PR DESCRIPTION
## Problem

`TestPeerService_Accept` (and other `net/peerservice` tests) started failing in CI:

```
pool.go:54: Unexpected call to *mock_transport.MockMultiConn.CloseChan([])
  because: there are no expected calls of the method "CloseChan" for that receiver
```

## Root cause

PR #693 (pool eviction) spawns `pool.evictOnClose` as a goroutine for **every** peer added to the pool (`net/pool/pool.go:180`, `net/pool/poolservice.go:64`). That goroutine subscribes to `pr.CloseChan()`, which the `peer` struct promotes from its embedded `transport.MultiConn` (`net/peer/peer.go:127`).

The shared `mockMC` helper in `peerservice_test.go` set up expectations for `Context()`, `Accept()` and `Close()` — but not `CloseChan()` — so the new background goroutine triggered a gomock *Unexpected call*. The eviction commit only touched `net/pool/` (and updated the pool package's own tests), so the downstream `net/peerservice` mock was never updated.

## Why CI caught it but local runs didn't

It's a goroutine-scheduling race. Measured over 50 runs of the pre-fix test:

| Build | PASS / FAIL |
|-------|-------------|
| plain `go test` | 6 / 44 (~12% pass by luck) |
| coverage (`-coverpkg=./...`, what CI runs) | 0 / 50 (100% fail) |
| `-race` | 0 / 50 (100% fail) |

Coverage instrumentation slows every path, so the eviction goroutine reliably calls `CloseChan()` before teardown → deterministic failure in CI, while a quick local run could pass by luck.

## Fix

Add the missing expectation to the shared `mockMC` helper, returning a nil receive-only channel (never fires) so the peer stays alive for the test — matching the existing `pool_test.go` and `rpctest.MockPeer` conventions.

## Verification

- `go test ./net/peerservice/ ./net/pool/ ./net/peer/` → ok
- `go test -cover -coverpkg=./... -count=5 ./net/peerservice/` → ok (was 0/50 before)