### PR TITLE
fix(headsync): guard syncLogger map against concurrent Sync

### DIFF
--- a/commonspace/headsync/synclogger.go
+++ b/commonspace/headsync/synclogger.go
@@ -1,6 +1,7 @@
 package headsync
 
 import (
+	"sync"
 	"time"
 
 	"github.com/anyproto/any-sync/app/logger"
@@ -8,6 +9,10 @@ import (
 )
 
 type syncLogger struct {
+	// mu is a pointer so copies of syncLogger (it is passed/stored by value)
+	// share the same mutex guarding lastLogged. logSyncDone may run from
+	// several goroutines at once (the periodic loop and on-demand DiffSync).
+	mu          *sync.Mutex
 	lastLogged  map[string]time.Time
 	logInterval time.Duration
 	logger.CtxLogger
@@ -15,6 +20,7 @@ type syncLogger struct {
 
 func newSyncLogger(log logger.CtxLogger, syncLogPeriodSecs int) syncLogger {
 	return syncLogger{
+		mu:          &sync.Mutex{},
 		lastLogged:  map[string]time.Time{},
 		logInterval: time.Duration(syncLogPeriodSecs) * time.Second,
 		CtxLogger:   log,
@@ -24,14 +30,17 @@ func newSyncLogger(log logger.CtxLogger, syncLogPeriodSecs int) syncLogger {
 func (s syncLogger) logSyncDone(peerId string, newIds, changedIds, removedIds, deltedIds int) {
 	now := time.Now()
 	differentIds := newIds + changedIds + removedIds + deltedIds
+	s.mu.Lock()
 	// always logging if some ids are different or there are no log interval
 	if differentIds == 0 && s.logInterval > 0 {
 		lastLogged := s.lastLogged[peerId]
 		if now.Before(lastLogged.Add(s.logInterval)) {
+			s.mu.Unlock()
 			return
 		}
 	}
 	s.lastLogged[peerId] = now
+	s.mu.Unlock()
 	s.Info("sync done:", zap.Int("newIds", newIds),
 		zap.Int("changedIds", changedIds),
 		zap.Int("removedIds", removedIds),

--- a/commonspace/headsync/synclogger.go
+++ b/commonspace/headsync/synclogger.go
@@ -9,9 +9,6 @@ import (
 )
 
 type syncLogger struct {
-	// mu is a pointer so copies of syncLogger (it is passed/stored by value)
-	// share the same mutex guarding lastLogged. logSyncDone may run from
-	// several goroutines at once (the periodic loop and on-demand DiffSync).
 	mu          *sync.Mutex
 	lastLogged  map[string]time.Time
 	logInterval time.Duration

--- a/commonspace/headsync/synclogger_test.go
+++ b/commonspace/headsync/synclogger_test.go
@@ -1,0 +1,31 @@
+package headsync
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/anyproto/any-sync/app/logger"
+)
+
+// TestSyncLogger_ConcurrentLogSyncDone guards against the data race that was
+// possible once Sync could run concurrently (the periodic loop plus an
+// on-demand DiffSync), both reaching logSyncDone on the same shared logger.
+// Run with -race.
+func TestSyncLogger_ConcurrentLogSyncDone(t *testing.T) {
+	l := newSyncLogger(logger.NewNamed("test"), logPeriodSecs)
+	const goroutines = 8
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				// differentIds == 0 forces the rate-limit branch that both
+				// reads and writes lastLogged.
+				l.logSyncDone("peer", 0, 0, 0, 0)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Fixes a data race introduced when `Space.SyncHeads` (#696) added a second goroutine that can run `diffSyncer.Sync` concurrently with the periodic loop.

Both callers reach `syncWithPeer → logSyncDone`, which reads and writes the shared `syncLogger.lastLogged` (`map[string]time.Time`) with no synchronization. The race detector flagged every report at `synclogger.go:34` (`s.lastLogged[peerId] = now`).

- **Goroutine A** — the periodic loop (`headSync.Run → periodicsync.loop → Sync`).
- **Goroutine B** — the on-demand kick (`Space.SyncHeads → headSync.DiffSync → Sync`).

Before `SyncHeads`, only the periodic loop ever called `Sync`, so the map was only ever touched by one goroutine and never raced.

## Fix

Guard `lastLogged` with a mutex in `logSyncDone`. The mutex is a **pointer** field (`*sync.Mutex`) because `syncLogger` is stored and passed **by value** — a pointer makes every copy share the one lock and keeps the struct copyable (no `copylocks` vet warning).

## Testing

- `go build ./...` — clean
- `go vet ./commonspace/headsync/` — no copylocks warning
- New `TestSyncLogger_ConcurrentLogSyncDone` hammers `logSyncDone` from 8 goroutines; passes under `-race`.
- `go test -race ./commonspace/headsync/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)