### PR TITLE
fix(commonspace): regenerate mock_commonspace to add SyncHeads

### DIFF
--- a/commonspace/mock_commonspace/mock_commonspace.go
+++ b/commonspace/mock_commonspace/mock_commonspace.go
@@ -267,6 +267,20 @@ func (mr *MockSpaceMockRecorder) StoredIds() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoredIds", reflect.TypeOf((*MockSpace)(nil).StoredIds))
 }
 
+// SyncHeads mocks base method.
+func (m *MockSpace) SyncHeads(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncHeads", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SyncHeads indicates an expected call of SyncHeads.
+func (mr *MockSpaceMockRecorder) SyncHeads(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncHeads", reflect.TypeOf((*MockSpace)(nil).SyncHeads), ctx)
+}
+
 // SyncStatus mocks base method.
 func (m *MockSpace) SyncStatus() syncstatus.StatusUpdater {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Problem

`SyncHeads(ctx context.Context) error` was added to the `commonspace.Space` interface (and implemented on the concrete `space` type) in 73227c80 (`feat(commonspace): add Space.SyncHeads for on-demand head sync`), but the gomock mock in `commonspace/mock_commonspace/mock_commonspace.go` was not regenerated.

As a result, `*mock_commonspace.MockSpace` no longer satisfies the `commonspace.Space` interface. This breaks downstream consumers that use `mock_commonspace.MockSpace` as a `commonspace.Space` in their tests (compilation failure: missing method `SyncHeads`).

## Fix

Regenerated the mock so `MockSpace` and `MockSpaceMockRecorder` include `SyncHeads`.

Regenerated via:
```
go install go.uber.org/mock/mockgen@v0.6.0
go generate ./commonspace/
```
(matches the existing `//go:generate mockgen ...` directive in `commonspace/spaceservice.go` and the pinned `go.uber.org/mock v0.6.0` in go.mod)

Diff is minimal: only the `SyncHeads` method + recorder are added (14 lines, single file). `go build ./...` and `go vet ./commonspace/mock_commonspace/...` pass.