### PR TITLE
headsync: push object trees immediately after registering a space on a peer

### DIFF
--- a/commonspace/headsync/diffsyncer.go
+++ b/commonspace/headsync/diffsyncer.go
@@ -128,16 +128,21 @@ func (d *diffSyncer) syncWithPeer(ctx context.Context, p peer.Peer) (err error) 
 	}
 	defer p.ReleaseDrpcConn(ctx, conn)
 
-	var (
-		cl        = d.clientFactory.Client(conn)
-		rdiff     = NewRemoteDiff(d.spaceId, cl)
-		syncAclId = d.syncAcl.Id()
-	)
-	storageId := d.keyValue.DefaultStore().Id()
+	cl := d.clientFactory.Client(conn)
+	rdiff := NewRemoteDiff(d.spaceId, cl)
 	newIds, changedIds, removedIds, err := d.diffManager.TryDiff(ctx, rdiff)
 	if err != nil {
 		return d.onDiffError(ctx, p, cl, err)
 	}
+	return d.applyDiff(ctx, p, newIds, changedIds, removedIds)
+}
+
+// applyDiff syncs the divergent ids resolved by a successful TryDiff round with
+// the peer: it routes the acl/storage roots to their dedicated syncers and hands
+// the remaining tree ids to treeSyncer.
+func (d *diffSyncer) applyDiff(ctx context.Context, p peer.Peer, newIds, changedIds, removedIds []string) (err error) {
+	syncAclId := d.syncAcl.Id()
+	storageId := d.keyValue.DefaultStore().Id()
 	totalLen := len(newIds) + len(changedIds) + len(removedIds)
 	// not syncing ids which were removed through settings document
 	missingIds := d.deletionState.Filter(newIds)
@@ -183,11 +188,34 @@ func (d *diffSyncer) onDiffError(ctx context.Context, p peer.Peer, cl spacesyncp
 		return err
 	}
 	// in case space is missing on peer, we should send push request
-	err = d.sendPushSpaceRequest(ctx, p.Id(), cl)
-	if err != nil {
+	if err = d.sendPushSpaceRequest(ctx, p.Id(), cl); err != nil {
 		return err
 	}
-	return nil
+	// SpacePush only registers the space on the peer (header + acl root + settings
+	// root) — it does NOT transfer object trees. Without an immediate follow-up the
+	// trees would be uploaded only on the next periodic head-sync round (a full
+	// SyncPeriod later), leaving a window in which the peer has the space but none
+	// of its trees, so a freshly-joined client requesting them gets "tree not
+	// found" until then. Now that the peer holds the space, run one more diff in
+	// the same flow so treeSyncer uploads the trees immediately.
+	//
+	// Guard against a tight loop: if the peer has not yet committed the space (a
+	// rare race), TryDiff returns ErrSpaceMissing again — we then fall back to the
+	// periodic round rather than pushing again (note we call applyDiff directly,
+	// not onDiffError, so a repeated ErrSpaceMissing cannot recurse).
+	newIds, changedIds, removedIds, err := d.diffManager.TryDiff(ctx, NewRemoteDiff(d.spaceId, cl))
+	if err != nil {
+		// A repeated ErrSpaceMissing means the peer has not committed the space
+		// yet (the rare race noted above): silently fall back to the periodic
+		// round. Any other error is a genuine follow-up failure — surface it the
+		// same way the first-round path does (Sync logs per-peer errors) instead
+		// of swallowing it.
+		if err != spacesyncproto.ErrSpaceMissing {
+			d.log.WarnCtx(ctx, "follow-up diff after space push failed", zap.Error(err))
+		}
+		return nil
+	}
+	return d.applyDiff(ctx, p, newIds, changedIds, removedIds)
 }
 
 func (d *diffSyncer) sendPushSpaceRequest(ctx context.Context, peerId string, cl spacesyncproto.DRPCSpaceSyncClient) (err error) {

--- a/commonspace/headsync/diffsyncer_test.go
+++ b/commonspace/headsync/diffsyncer_test.go
@@ -223,10 +223,15 @@ func TestDiffSyncer(t *testing.T) {
 		fx.peerManagerMock.EXPECT().
 			GetResponsiblePeers(gomock.Any()).
 			Return([]peer.Peer{rpctest.MockPeer{}}, nil)
-		fx.diffContainerMock.EXPECT().DiffTypeCheck(gomock.Any(), gomock.Any()).Return(true, fx.diffMock, nil)
+		// After the push registers the space, onDiffError runs the diff once more
+		// in the same flow. Here the peer has not yet committed the space, so the
+		// second TryDiff also returns ErrSpaceMissing and we fall back to the
+		// periodic round (no second push, no tree sync).
+		fx.diffContainerMock.EXPECT().DiffTypeCheck(gomock.Any(), gomock.Any()).Return(true, fx.diffMock, nil).Times(2)
 		fx.diffMock.EXPECT().
 			Diff(gomock.Any(), gomock.Eq(remDiff)).
-			Return(nil, nil, nil, spacesyncproto.ErrSpaceMissing)
+			Return(nil, nil, nil, spacesyncproto.ErrSpaceMissing).
+			Times(2)
 
 		fx.storageMock.EXPECT().AclStorage().Return(aclStorageMock, nil)
 		fx.stateStorage.EXPECT().GetState(gomock.Any()).Return(statestorage.State{
@@ -247,6 +252,121 @@ func TestDiffSyncer(t *testing.T) {
 		fx.clientMock.EXPECT().
 			SpacePush(gomock.Any(), newPushSpaceRequestMatcher(fx.spaceState.SpaceId, aclRootId, settingsId, credential, spaceHeader)).
 			Return(nil, nil)
+		fx.peerManagerMock.EXPECT().SendMessage(gomock.Any(), "peerId", gomock.Any()).Return(nil)
+		fx.peerManagerMock.EXPECT().KeepAlive(gomock.Any())
+
+		require.NoError(t, fx.diffSyncer.Sync(ctx))
+	})
+
+	t.Run("diff syncer sync space missing then pushes trees in same flow", func(t *testing.T) {
+		fx := newHeadSyncFixture(t)
+		fx.initDiffSyncer(t)
+		defer fx.stop()
+		mPeer := rpctest.MockPeer{}
+		fx.aclMock.EXPECT().Id().AnyTimes().Return("aclId")
+		fx.treeSyncerMock.EXPECT().ShouldSync(gomock.Any()).Return(true)
+		aclStorageMock := mock_list.NewMockStorage(fx.ctrl)
+		settingsStorage := mock_objecttree.NewMockStorage(fx.ctrl)
+		settingsId := "settingsId"
+		aclRootId := "aclRootId"
+		spaceHeader := &spacesyncproto.RawSpaceHeaderWithId{
+			RawHeader: []byte{1},
+		}
+		credential := []byte("credential")
+		remDiff := NewRemoteDiff(fx.spaceState.SpaceId, fx.clientMock)
+
+		fx.peerManagerMock.EXPECT().
+			GetResponsiblePeers(gomock.Any()).
+			Return([]peer.Peer{mPeer}, nil)
+		fx.diffContainerMock.EXPECT().DiffTypeCheck(gomock.Any(), gomock.Any()).Return(true, fx.diffMock, nil).Times(2)
+		// First diff: space missing -> triggers push. Second diff (after push, same
+		// flow): the peer now holds the (still empty) space, so the owner's tree
+		// surfaces as a REMOVED id (owner has it, peer lacks it -> ldiff
+		// removedIds), which applyDiff routes into the `existing` list that
+		// treeSyncer pushes. It is uploaded immediately instead of waiting for the
+		// next periodic head-sync round.
+		gomock.InOrder(
+			fx.diffMock.EXPECT().Diff(gomock.Any(), gomock.Eq(remDiff)).Return(nil, nil, nil, spacesyncproto.ErrSpaceMissing),
+			fx.diffMock.EXPECT().Diff(gomock.Any(), gomock.Eq(remDiff)).Return(nil, nil, []string{"tree1"}, nil),
+		)
+		fx.storageMock.EXPECT().AclStorage().Return(aclStorageMock, nil)
+		fx.stateStorage.EXPECT().GetState(gomock.Any()).Return(statestorage.State{
+			SettingsId:  settingsId,
+			SpaceHeader: []byte{1},
+		}, nil)
+		fx.storageMock.EXPECT().TreeStorage(gomock.Any(), settingsId).Return(settingsStorage, nil)
+		settingsStorage.EXPECT().Root(gomock.Any()).Return(objecttree.StorageChange{RawChange: nil, Id: settingsId}, nil)
+		aclStorageMock.EXPECT().
+			Root(gomock.Any()).
+			Return(list.StorageRecord{
+				Id: aclRootId,
+			}, nil)
+		fx.credentialProviderMock.EXPECT().
+			GetCredential(gomock.Any(), spaceHeader).
+			Return(credential, nil)
+		fx.clientMock.EXPECT().
+			SpacePush(gomock.Any(), newPushSpaceRequestMatcher(fx.spaceState.SpaceId, aclRootId, settingsId, credential, spaceHeader)).
+			Return(nil, nil)
+		fx.peerManagerMock.EXPECT().SendMessage(gomock.Any(), "peerId", gomock.Any()).Return(nil)
+		// follow-up diff result is applied: the tree id arrives as a removed id and
+		// is handed to treeSyncer as an `existing` id (the bucket treeSyncer pushes),
+		// with no `missing` ids.
+		fx.deletionStateMock.EXPECT().Filter([]string{"tree1"}).Return([]string{"tree1"}).Times(1)
+		fx.deletionStateMock.EXPECT().Filter(nil).Return(nil).Times(2)
+		fx.treeSyncerMock.EXPECT().SyncAll(gomock.Any(), mPeer, []string{"tree1"}, gomock.Len(0)).Return(nil)
+		fx.peerManagerMock.EXPECT().KeepAlive(gomock.Any())
+
+		require.NoError(t, fx.diffSyncer.Sync(ctx))
+	})
+
+	t.Run("diff syncer sync space missing then follow-up diff errors", func(t *testing.T) {
+		fx := newHeadSyncFixture(t)
+		fx.initDiffSyncer(t)
+		defer fx.stop()
+		fx.aclMock.EXPECT().Id().AnyTimes().Return("aclId")
+		fx.treeSyncerMock.EXPECT().ShouldSync(gomock.Any()).Return(true)
+		aclStorageMock := mock_list.NewMockStorage(fx.ctrl)
+		settingsStorage := mock_objecttree.NewMockStorage(fx.ctrl)
+		settingsId := "settingsId"
+		aclRootId := "aclRootId"
+		spaceHeader := &spacesyncproto.RawSpaceHeaderWithId{
+			RawHeader: []byte{1},
+		}
+		credential := []byte("credential")
+		remDiff := NewRemoteDiff(fx.spaceState.SpaceId, fx.clientMock)
+
+		fx.peerManagerMock.EXPECT().
+			GetResponsiblePeers(gomock.Any()).
+			Return([]peer.Peer{rpctest.MockPeer{}}, nil)
+		fx.diffContainerMock.EXPECT().DiffTypeCheck(gomock.Any(), gomock.Any()).Return(true, fx.diffMock, nil).Times(2)
+		// First diff: space missing -> push. Second diff (after push) fails with a
+		// transient error that is NOT ErrSpaceMissing: we must not push again and
+		// must not sync trees; the round falls back to the periodic loop and Sync
+		// still returns nil (per-peer errors are not fatal).
+		gomock.InOrder(
+			fx.diffMock.EXPECT().Diff(gomock.Any(), gomock.Eq(remDiff)).Return(nil, nil, nil, spacesyncproto.ErrSpaceMissing),
+			fx.diffMock.EXPECT().Diff(gomock.Any(), gomock.Eq(remDiff)).Return(nil, nil, nil, context.Canceled),
+		)
+		fx.storageMock.EXPECT().AclStorage().Return(aclStorageMock, nil)
+		fx.stateStorage.EXPECT().GetState(gomock.Any()).Return(statestorage.State{
+			SettingsId:  settingsId,
+			SpaceHeader: []byte{1},
+		}, nil)
+		fx.storageMock.EXPECT().TreeStorage(gomock.Any(), settingsId).Return(settingsStorage, nil)
+		settingsStorage.EXPECT().Root(gomock.Any()).Return(objecttree.StorageChange{RawChange: nil, Id: settingsId}, nil)
+		aclStorageMock.EXPECT().
+			Root(gomock.Any()).
+			Return(list.StorageRecord{
+				Id: aclRootId,
+			}, nil)
+		fx.credentialProviderMock.EXPECT().
+			GetCredential(gomock.Any(), spaceHeader).
+			Return(credential, nil)
+		// exactly one push; SyncAll must NOT be called (no EXPECT for it).
+		fx.clientMock.EXPECT().
+			SpacePush(gomock.Any(), newPushSpaceRequestMatcher(fx.spaceState.SpaceId, aclRootId, settingsId, credential, spaceHeader)).
+			Return(nil, nil).
+			Times(1)
 		fx.peerManagerMock.EXPECT().SendMessage(gomock.Any(), "peerId", gomock.Any()).Return(nil)
 		fx.peerManagerMock.EXPECT().KeepAlive(gomock.Any())
 


### PR DESCRIPTION
## Problem
On the **first** head-sync round against a peer that does not yet have the space, `diffManager.TryDiff` returns `ErrSpaceMissing`; `syncWithPeer` early-returns into `onDiffError`, which sends a `SpacePush`. `SpacePush` is a **registration handshake** — `SpacePayload` carries only the space header, ACL root and settings root, **not object trees**. Previously `onDiffError` returned right after the push, so the object trees were uploaded only on the **next periodic head-sync round** (a full `SyncPeriod` later — 20s in anytype-heart).

This left a window in which the peer (a node, and transitively a freshly-joined client that reactively requests trees from it) had the space **registered but none of its trees**, so tree requests failed with `tree not found` for up to a `SyncPeriod`.

## Fix
After a successful `sendPushSpaceRequest` the peer now holds the space, so run the diff **once more in the same flow**: `TryDiff` now succeeds, the owner's trees surface as divergent ids, and `treeSyncer` uploads them immediately.

- Refactor the post-`TryDiff` body of `syncWithPeer` into `applyDiff(...)` and reuse it (byte-faithful extraction).
- The follow-up diff calls `applyDiff` **directly** (not `onDiffError`), so a transient repeated `ErrSpaceMissing` cannot recurse — it falls back to the periodic round. Any other follow-up error is `Warn`-logged (not silently swallowed), matching the first-round error path.
- Protocol unchanged: `SpacePush` stays header-only.

## Scope / caveat
This is an **owner→node** change (the node receives the trees in the same round it is registered). The join-latency improvement is **transitive** — the node holds the trees ~`SyncPeriod` sooner, so a joiner's *reactive* tree request (`treeRemoteGetter`) succeeds instead of returning `tree not found`. No joiner-side path is changed.

## Why not alternatives
- Embedding trees in the `SpacePush` payload would conflate registration with bulk transfer and bypass the streaming tree-sync path — rejected.
- A single on-demand `SyncHeads`/`Kick` call only triggers the registration round; trees still need a second round. The in-flow re-diff makes registration + first reconciliation atomic.

## Verification
- `go test -race ./commonspace/headsync/...` — green. Updated the `space missing` test (now asserts the second TryDiff → graceful fallback, no second push) and added two tests: (a) push → second diff succeeds → `SyncAll` pushes the tree as an `existing` id in the same round; (b) push → second diff errors → exactly one push, no `SyncAll`, `Sync` returns nil.
- End-to-end (anytype-heart against this branch): owner server log shows the tree `sync done` **~16–173ms** after `space push completed successfully` (was **~20s**); a freshly-joined second account's `tree not found` count dropped **17 → 0**.

## Notes for downstream (anytype-heart)
No API change here, but heart pins an older any-sync; when bumping, `virtualCommonSpace` needs a no-op `SyncHeads` (added in v0.12.9's `Space` interface — unrelated to this change).