### PR TITLE
fix(ocache): prevent close-channel double-close on busy revert (GO-7332)

### DIFF
--- a/app/ocache/entry.go
+++ b/app/ocache/entry.go
@@ -101,7 +101,12 @@ func (e *entry) setClosing(wait bool) (prevState, curState entryState) {
 	e.mx.Lock()
 	prevState = e.state
 	curState = e.state
-	if e.state == entryStateClosing {
+	// Loop rather than `if`: after waking from <-waitCh another goroutine may
+	// have already moved the entry back to closing (e.g. a busy GC/TryRemove
+	// reverted it to active and a concurrent remover re-acquired it). Re-check
+	// and wait on the new close channel instead of overwriting e.close, which
+	// would let two removers close the same channel twice (GO-7332).
+	for e.state == entryStateClosing {
 		waitCh := e.close
 		e.mx.Unlock()
 		if !wait {

--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -204,6 +204,16 @@ func (c *oCache) Remove(ctx context.Context, id string) (ok bool, err error) {
 	return c.remove(ctx, e)
 }
 
+// closeAndDelete finalizes a closing entry under c.mu. The deferred unlock
+// guarantees c.mu is released even if setClosed panics, so a panic in the
+// close path can never leave the whole cache wedged (GO-7332 hardening).
+func (c *oCache) closeAndDelete(e *entry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e.setClosed()
+	delete(c.data, e.id)
+}
+
 func (c *oCache) remove(ctx context.Context, e *entry) (ok bool, err error) {
 	if _, err = e.waitLoad(ctx, e.id); err != nil {
 		return false, err
@@ -212,10 +222,7 @@ func (c *oCache) remove(ctx context.Context, e *entry) (ok bool, err error) {
 	if curState == entryStateClosing {
 		ok = true
 		err = e.value.Close()
-		c.mu.Lock()
-		e.setClosed()
-		delete(c.data, e.id)
-		c.mu.Unlock()
+		c.closeAndDelete(e)
 	}
 	return
 }
@@ -272,10 +279,7 @@ func (c *oCache) TryRemove(id string) (ok bool, err error) {
 		return false, nil
 	}
 
-	c.mu.Lock()
-	e.setClosed()
-	delete(c.data, e.id)
-	c.mu.Unlock()
+	c.closeAndDelete(e)
 	return true, nil
 }
 
@@ -366,10 +370,7 @@ func (c *oCache) GC() {
 			continue
 		} else {
 			closedNum++
-			c.mu.Lock()
-			e.setClosed()
-			delete(c.data, e.id)
-			c.mu.Unlock()
+			c.closeAndDelete(e)
 		}
 	}
 	c.metricsClosed(closedNum, size)

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -669,61 +669,82 @@ func (o *busyRevertObject) TryClose(objectTTL time.Duration) (res bool, err erro
 // channel, every woken remover re-enters the closing path. The second one
 // overwrites e.close, and both call setClosed -> close(e.close) on the same
 // channel: "panic: close of closed channel".
+//
+// Covered combinations: the revert is driven by both TryRemove and GC (the two
+// setActive(true) call sites), against 2 and 3 parked removers (3 removers is
+// also what surfaces the pre-fix cache-wide deadlock when setClosed panics
+// while holding c.mu).
 func TestOCache_RemoveBusyRevertDoubleClose(t *testing.T) {
-	obj := &busyRevertObject{release: make(chan struct{})}
-	c := New(
-		func(ctx context.Context, id string) (Object, error) { return obj, nil },
-		WithGCPeriod(0), // no background GC; we drive the revert manually
-	).(*oCache)
-	require.NoError(t, c.Add("id", obj))
-
-	// 1) busy remover: marks the entry closing (creates close channel), then
-	//    blocks in TryClose holding the entry in entryStateClosing.
-	tryDone := make(chan struct{})
-	go func() {
-		defer close(tryDone)
-		_, _ = c.TryRemove("id")
-	}()
-
-	// wait until the entry is actually in the closing state
-	require.Eventually(t, func() bool {
-		c.mu.Lock()
-		e, ok := c.data["id"]
-		c.mu.Unlock()
-		if !ok {
-			return false
-		}
-		e.mx.Lock()
-		st := e.state
-		e.mx.Unlock()
-		return st == entryStateClosing
-	}, time.Second, time.Millisecond)
-
-	// 2) two removers park on the closing channel.
-	var panicMsg atomic.Value
-	var wg sync.WaitGroup
-	wg.Add(2)
-	worker := func() {
-		defer wg.Done()
-		defer func() {
-			if r := recover(); r != nil {
-				panicMsg.Store(fmt.Sprint(r))
-			}
-		}()
-		_, _ = c.Remove(ctx, "id")
+	reverters := []struct {
+		name string
+		ttl  time.Duration // 0 makes the Added entry eligible for GC immediately
+		fn   func(c *oCache)
+	}{
+		{"TryRemove", time.Minute, func(c *oCache) { _, _ = c.TryRemove("id") }},
+		{"GC", 0, func(c *oCache) { c.GC() }},
 	}
-	go worker()
-	go worker()
-	time.Sleep(20 * time.Millisecond) // let both park on <-e.close
+	for _, rev := range reverters {
+		for _, removers := range []int{2, 3} {
+			rev, removers := rev, removers
+			t.Run(fmt.Sprintf("%s/%dremovers", rev.name, removers), func(t *testing.T) {
+				obj := &busyRevertObject{release: make(chan struct{})}
+				c := New(
+					func(ctx context.Context, id string) (Object, error) { return obj, nil },
+					WithGCPeriod(0), // no background GC; we drive the revert manually
+					WithTTL(rev.ttl),
+				).(*oCache)
+				require.NoError(t, c.Add("id", obj))
 
-	// 3) release TryClose -> "busy" -> setActive(true) closes the channel and
-	//    reverts to active, waking both removers into the racy path.
-	close(obj.release)
+				// 1) busy reverter: marks the entry closing (creates the close
+				//    channel), then blocks in TryClose holding it in closing.
+				revDone := make(chan struct{})
+				go func() {
+					defer close(revDone)
+					rev.fn(c)
+				}()
 
-	<-tryDone
-	wg.Wait()
+				// wait until the entry is actually in the closing state
+				require.Eventually(t, func() bool {
+					c.mu.Lock()
+					e, ok := c.data["id"]
+					c.mu.Unlock()
+					if !ok {
+						return false
+					}
+					e.mx.Lock()
+					st := e.state
+					e.mx.Unlock()
+					return st == entryStateClosing
+				}, time.Second, time.Millisecond)
 
-	if msg := panicMsg.Load(); msg != nil {
-		t.Fatalf("Remove double-closed the entry's close channel: panic %q", msg)
+				// 2) removers park on the closing channel.
+				var panicMsg atomic.Value
+				var wg sync.WaitGroup
+				wg.Add(removers)
+				for i := 0; i < removers; i++ {
+					go func() {
+						defer wg.Done()
+						defer func() {
+							if r := recover(); r != nil {
+								panicMsg.Store(fmt.Sprint(r))
+							}
+						}()
+						_, _ = c.Remove(ctx, "id")
+					}()
+				}
+				time.Sleep(20 * time.Millisecond) // let removers park on <-e.close
+
+				// 3) release TryClose -> "busy" -> setActive(true) closes the
+				//    channel and reverts to active, waking the removers.
+				close(obj.release)
+
+				<-revDone
+				wg.Wait()
+
+				if msg := panicMsg.Load(); msg != nil {
+					t.Fatalf("Remove double-closed the entry's close channel: panic %q", msg)
+				}
+			})
+		}
 	}
 }

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -640,3 +640,90 @@ func TestOCache_RemoveSame(t *testing.T) {
 		require.False(t, ok)
 	})
 }
+
+// busyRevertObject deterministically drives the
+// active -> closing -> active "busy revert" path: TryClose blocks until
+// release is closed, then reports "not closed" (busy) so the cache reverts
+// the entry to active via setActive(true). Close is benign/idempotent on
+// purpose, so a double removal surfaces as the close-channel double-close
+// (the production panic) rather than masking it.
+type busyRevertObject struct {
+	release chan struct{}
+}
+
+func (o *busyRevertObject) Close() (err error) {
+	// Hold the entry between setClosing and setClosed long enough for a
+	// second parked remover to observe it mid-close and overwrite e.close.
+	time.Sleep(2 * time.Millisecond)
+	return nil
+}
+
+func (o *busyRevertObject) TryClose(objectTTL time.Duration) (res bool, err error) {
+	<-o.release
+	return false, nil
+}
+
+// TestOCache_RemoveBusyRevertDoubleClose reproduces a panic that crashes the
+// process on laptop wake (GO-7332): when a busy TryRemove/GC reverts an entry
+// back to active while two or more Remove callers are parked on its close
+// channel, every woken remover re-enters the closing path. The second one
+// overwrites e.close, and both call setClosed -> close(e.close) on the same
+// channel: "panic: close of closed channel".
+func TestOCache_RemoveBusyRevertDoubleClose(t *testing.T) {
+	obj := &busyRevertObject{release: make(chan struct{})}
+	c := New(
+		func(ctx context.Context, id string) (Object, error) { return obj, nil },
+		WithGCPeriod(0), // no background GC; we drive the revert manually
+	).(*oCache)
+	require.NoError(t, c.Add("id", obj))
+
+	// 1) busy remover: marks the entry closing (creates close channel), then
+	//    blocks in TryClose holding the entry in entryStateClosing.
+	tryDone := make(chan struct{})
+	go func() {
+		defer close(tryDone)
+		_, _ = c.TryRemove("id")
+	}()
+
+	// wait until the entry is actually in the closing state
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		e, ok := c.data["id"]
+		c.mu.Unlock()
+		if !ok {
+			return false
+		}
+		e.mx.Lock()
+		st := e.state
+		e.mx.Unlock()
+		return st == entryStateClosing
+	}, time.Second, time.Millisecond)
+
+	// 2) two removers park on the closing channel.
+	var panicMsg atomic.Value
+	var wg sync.WaitGroup
+	wg.Add(2)
+	worker := func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				panicMsg.Store(fmt.Sprint(r))
+			}
+		}()
+		_, _ = c.Remove(ctx, "id")
+	}
+	go worker()
+	go worker()
+	time.Sleep(20 * time.Millisecond) // let both park on <-e.close
+
+	// 3) release TryClose -> "busy" -> setActive(true) closes the channel and
+	//    reverts to active, waking both removers into the racy path.
+	close(obj.release)
+
+	<-tryDone
+	wg.Wait()
+
+	if msg := panicMsg.Load(); msg != nil {
+		t.Fatalf("Remove double-closed the entry's close channel: panic %q", msg)
+	}
+}


### PR DESCRIPTION
## Problem

Full-process panic `close of closed channel` at `ocache.(*entry).setClosed`, reached via `pool.evictOnClose -> ocache.RemoveSame -> remove -> setClosed`. Hit in practice on laptop wake, when all peer connections drop at once and the pool fires many concurrent `evictOnClose -> RemoveSame` calls against the same entries while GC runs.

## Root cause

`entry.setClosing(wait=true)` waited on the entry's close channel with an `if`, then fell through and **unconditionally overwrote `e.close`**. When a busy `GC`/`TryRemove` reverted an entry `closing -> active` via `setActive(true)` while two or more `Remove` callers were parked on its close channel, every woken remover re-entered the closing path; the second overwrote the first's channel and both called `setClosed -> close(e.close)` on the same channel.

At >=3 concurrent removers it is worse than a crash: `setClosed` ran under `c.mu` with no deferred unlock, so the panic orphaned `c.mu` and wedged the whole cache (permanent deadlock).

## When it was introduced

- The latent `setClosing` defect (wait-on-channel then fall through and overwrite `e.close`) has existed since `86b66121` "More tests and split entry" (2023-03-09), first released in v0.1.0.
- It was unreachable in practice until eager per-peer eviction landed in `08f8d6d3` "pool: evict peers from cache eagerly when the connection closes" (2026-06-01, first released in v0.12.6), which made many `RemoveSame`/`Remove` calls race on the same entry — exposing the latent bug.

## Fix

- `setClosing`: `if` -> `for`. A woken waiter re-checks the state and waits on the **new** close channel instead of clobbering it, so exactly one remover ever owns and closes a given channel. This also removes the secondary symptoms (object `Close()` called twice, leaked close channel).
- `closeAndDelete`: route the three close sites (`remove`/`TryRemove`/`GC`) through a helper that unlocks `c.mu` via `defer`, so a panic in the close path can never wedge the cache. Not made idempotent on purpose — a silent double-close would mask regressions.

## Test

`TestOCache_RemoveBusyRevertDoubleClose`, table-driven: revert driven by both `TryRemove` and `GC` x 2 and 3 parked removers. Fails on the pre-fix code with `"close of closed channel"`; passes with the fix (incl. `-race`, `-count=50`). `net/pool` passes under `-race`.