### PR TITLE
feat(sync): selective-sync hooks — tree probe requests + optional PullFilter (SYN-18)

### DIFF
--- a/commonspace/object/tree/synctree/request.go
+++ b/commonspace/object/tree/synctree/request.go
@@ -9,6 +9,7 @@ type InnerRequest struct {
 	heads        []string
 	snapshotPath []string
 	root         *treechangeproto.RawTreeChangeWithId
+	probe        bool
 }
 
 func (r *InnerRequest) MsgSize() uint64 {
@@ -29,10 +30,21 @@ func NewRequest(peerId, spaceId, objectId string, heads []string, snapshotPath [
 	})
 }
 
+// NewProbeRequest creates a request for the tree's root and current heads
+// only — the responder sends no change bodies. Old responders ignore the
+// probe flag and stream the full tree, so the caller's response collector
+// must handle both shapes.
+func NewProbeRequest(peerId, spaceId, objectId string) *objectmessages.Request {
+	return objectmessages.NewRequest(peerId, spaceId, objectId, &InnerRequest{
+		probe: true,
+	})
+}
+
 func (r *InnerRequest) Marshall() ([]byte, error) {
 	msg := &treechangeproto.TreeFullSyncRequest{
 		Heads:        r.heads,
 		SnapshotPath: r.snapshotPath,
+		Probe:        r.probe,
 	}
 	req := treechangeproto.WrapFullRequest(msg, r.root)
 	return req.MarshalVT()

--- a/commonspace/object/tree/synctree/synchandler.go
+++ b/commonspace/object/tree/synctree/synchandler.go
@@ -113,6 +113,31 @@ func (s *syncHandler) HandleStreamRequest(ctx context.Context, rq syncdeps.Reque
 	if request == nil {
 		return nil, ErrUnexpectedRequestType
 	}
+	if request.Probe {
+		// A probe declares nothing about the requester's state, so no
+		// counter-request — just root + current heads, no change bodies.
+		s.tree.Lock()
+		heads := make([]string, len(s.tree.Heads()))
+		copy(heads, s.tree.Heads())
+		snapshotPath, err := s.tree.SnapshotPath()
+		root := s.tree.Header()
+		s.tree.Unlock()
+		if err != nil {
+			return nil, err
+		}
+		resp := &response.Response{
+			SpaceId:      s.spaceId,
+			ObjectId:     req.ObjectId(),
+			Heads:        heads,
+			SnapshotPath: snapshotPath,
+			Root:         root,
+		}
+		protoResp, err := resp.ProtoMessage()
+		if err != nil {
+			return nil, err
+		}
+		return nil, send(protoResp)
+	}
 	s.tree.Lock()
 	curHeads := s.tree.Heads()
 	log.Debug("got stream request",

--- a/commonspace/object/tree/synctree/synchandler_test.go
+++ b/commonspace/object/tree/synctree/synchandler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/object/tree/synctree/response"
 	"github.com/anyproto/any-sync/commonspace/object/tree/synctree/response/mock_response"
 	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
+	"github.com/anyproto/any-sync/commonspace/spacesyncproto"
 	"github.com/anyproto/any-sync/commonspace/sync/objectsync/objectmessages"
 	"github.com/anyproto/any-sync/commonspace/syncstatus/mock_syncstatus"
 	"github.com/anyproto/any-sync/net/peer"
@@ -335,6 +336,61 @@ func TestSyncHandler_HandleStreamRequest(t *testing.T) {
 		require.Equal(t, returnReq, req)
 		require.Equal(t, 1, callCount)
 	})
+}
+
+func TestSyncHandler_HandleStreamRequest_Probe(t *testing.T) {
+	t.Run("probe request, we send root and heads without changes, no request", func(t *testing.T) {
+		fx := newSyncHandlerFixture(t)
+		defer fx.finish()
+		fullRequest := &treechangeproto.TreeFullSyncRequest{
+			Probe: true,
+		}
+		wrapped := treechangeproto.WrapFullRequest(fullRequest, nil)
+		marshaled, err := wrapped.MarshalVT()
+		require.NoError(t, err)
+		request := objectmessages.NewByteRequest("peerId", "spaceId", "objectId", marshaled)
+		root := &treechangeproto.RawTreeChangeWithId{
+			RawChange: []byte("rootChange"),
+			Id:        "objectId",
+		}
+		fx.tree.EXPECT().Heads().AnyTimes().Return([]string{"curHead"})
+		fx.tree.EXPECT().SnapshotPath().Return([]string{"objectId"}, nil)
+		fx.tree.EXPECT().Header().Return(root)
+		ctx = peer.CtxWithPeerId(ctx, "peerId")
+		callCount := 0
+		req, err := fx.syncHandler.HandleStreamRequest(ctx, request, testUpdater{}, func(resp proto.Message) error {
+			callCount++
+			msg, ok := resp.(*spacesyncproto.ObjectSyncMessage)
+			require.True(t, ok)
+			treeMsg := &treechangeproto.TreeSyncMessage{}
+			require.NoError(t, treeMsg.UnmarshalVT(msg.Payload))
+			fullResp := treeMsg.GetContent().GetFullSyncResponse()
+			require.NotNil(t, fullResp)
+			require.Equal(t, []string{"curHead"}, fullResp.Heads)
+			require.Empty(t, fullResp.Changes)
+			require.Equal(t, root.Id, treeMsg.RootChange.Id)
+			require.Equal(t, root.RawChange, treeMsg.RootChange.RawChange)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Nil(t, req)
+		require.Equal(t, 1, callCount)
+	})
+}
+
+func TestNewProbeRequest(t *testing.T) {
+	req := NewProbeRequest("peerId", "spaceId", "objectId")
+	protoMsg, err := req.Proto()
+	require.NoError(t, err)
+	msg, ok := protoMsg.(*spacesyncproto.ObjectSyncMessage)
+	require.True(t, ok)
+	treeMsg := &treechangeproto.TreeSyncMessage{}
+	require.NoError(t, treeMsg.UnmarshalVT(msg.Payload))
+	fullReq := treeMsg.GetContent().GetFullSyncRequest()
+	require.NotNil(t, fullReq)
+	require.True(t, fullReq.Probe)
+	require.Empty(t, fullReq.Heads)
+	require.Empty(t, fullReq.Changes)
 }
 
 func TestSyncHandler_HandleResponse(t *testing.T) {

--- a/commonspace/object/tree/synctree/synctree.go
+++ b/commonspace/object/tree/synctree/synctree.go
@@ -85,6 +85,12 @@ type BuildDeps struct {
 	BuildObjectTree    objecttree.BuildObjectTreeFunc
 	ValidateObjectTree objecttree.ValidatorFunc
 	StatsCollector     *TreeStatsCollector
+	// Probe makes the remote fetch request the tree's root and current
+	// heads only (no change bodies). The response never yields a usable
+	// tree by itself, so Probe callers must supply a ValidateObjectTree
+	// that inspects the payload and returns an error to abort the build.
+	// Old responders ignore the flag and stream the full tree.
+	Probe bool
 }
 
 var newTreeGetter = func(deps BuildDeps, treeId string) treeGetter {

--- a/commonspace/object/tree/synctree/treeremotegetter.go
+++ b/commonspace/object/tree/synctree/treeremotegetter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
 	"github.com/anyproto/any-sync/commonspace/object/tree/treestorage"
+	"github.com/anyproto/any-sync/commonspace/sync/objectsync/objectmessages"
 	"github.com/anyproto/any-sync/net/peer"
 )
 
@@ -51,7 +52,12 @@ func (t treeRemoteGetter) getPeers(ctx context.Context) (peerIds []string, err e
 
 func (t treeRemoteGetter) treeRequest(ctx context.Context, peerId string) (collector *fullResponseCollector, err error) {
 	collector = createCollector(t.deps)
-	req := t.deps.SyncClient.CreateNewTreeRequest(peerId, t.treeId)
+	var req *objectmessages.Request
+	if t.deps.Probe {
+		req = NewProbeRequest(peerId, t.deps.SpaceId, t.treeId)
+	} else {
+		req = t.deps.SyncClient.CreateNewTreeRequest(peerId, t.treeId)
+	}
 	err = t.deps.SyncClient.SendTreeRequest(ctx, req, collector)
 	if err != nil {
 		return nil, err

--- a/commonspace/object/tree/synctree/treeremotegetter_test.go
+++ b/commonspace/object/tree/synctree/treeremotegetter_test.go
@@ -9,7 +9,9 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/anyproto/any-sync/commonspace/object/tree/synctree/mock_synctree"
+	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
 	"github.com/anyproto/any-sync/commonspace/peermanager/mock_peermanager"
+	"github.com/anyproto/any-sync/commonspace/spacesyncproto"
 	"github.com/anyproto/any-sync/commonspace/sync/objectsync/objectmessages"
 	"github.com/anyproto/any-sync/net/peer"
 	"github.com/anyproto/any-sync/net/peer/mock_peer"
@@ -102,5 +104,33 @@ func TestTreeRemoteGetter(t *testing.T) {
 		fx.syncClientMock.EXPECT().SendTreeRequest(tCtx, treeRequest, coll).Return(fmt.Errorf("error"))
 		_, _, err := fx.treeGetter.treeRequestLoop(tCtx)
 		require.Error(t, err)
+	})
+
+	t.Run("probe deps send a probe request instead of a full one", func(t *testing.T) {
+		fx := newTreeRemoteGetterFixture(t)
+		defer fx.stop()
+		fx.treeGetter.deps.Probe = true
+		coll := newFullResponseCollector(BuildDeps{})
+		createCollector = func(deps BuildDeps) *fullResponseCollector {
+			return coll
+		}
+		tCtx := peer.CtxWithPeerId(ctx, peerId)
+		fx.syncClientMock.EXPECT().SendTreeRequest(tCtx, gomock.Any(), coll).DoAndReturn(
+			func(_ context.Context, rq any, _ any) error {
+				req, ok := rq.(*objectmessages.Request)
+				require.True(t, ok)
+				protoMsg, err := req.Proto()
+				require.NoError(t, err)
+				treeMsg := &treechangeproto.TreeSyncMessage{}
+				require.NoError(t, treeMsg.UnmarshalVT(protoMsg.(*spacesyncproto.ObjectSyncMessage).Payload))
+				fullReq := treeMsg.GetContent().GetFullSyncRequest()
+				require.NotNil(t, fullReq)
+				require.True(t, fullReq.Probe)
+				return nil
+			})
+		retColl, pId, err := fx.treeGetter.treeRequestLoop(tCtx)
+		require.NoError(t, err)
+		require.Equal(t, peerId, pId)
+		require.Equal(t, coll, retColl)
 	})
 }

--- a/commonspace/object/tree/treechangeproto/protos/treechange.proto
+++ b/commonspace/object/tree/treechangeproto/protos/treechange.proto
@@ -121,6 +121,10 @@ message TreeFullSyncRequest {
     repeated string heads = 1;
     repeated RawTreeChangeWithId changes = 2;
     repeated string snapshotPath = 3;
+    // probe asks the responder for the tree's root and current heads only,
+    // with no change bodies. Old responders ignore it and stream the full
+    // tree; a probing requester must be ready for both response shapes.
+    bool probe = 4;
 }
 
 // TreeFullSyncResponse is a message sent as a response for a specific full sync

--- a/commonspace/object/tree/treechangeproto/treechange.pb.go
+++ b/commonspace/object/tree/treechangeproto/treechange.pb.go
@@ -803,10 +803,14 @@ func (x *TreeHeadUpdate) GetSnapshotPath() []string {
 
 // TreeHeadUpdate is a message sent when document needs full sync
 type TreeFullSyncRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Heads         []string               `protobuf:"bytes,1,rep,name=heads,proto3" json:"heads,omitempty"`
-	Changes       []*RawTreeChangeWithId `protobuf:"bytes,2,rep,name=changes,proto3" json:"changes,omitempty"`
-	SnapshotPath  []string               `protobuf:"bytes,3,rep,name=snapshotPath,proto3" json:"snapshotPath,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Heads        []string               `protobuf:"bytes,1,rep,name=heads,proto3" json:"heads,omitempty"`
+	Changes      []*RawTreeChangeWithId `protobuf:"bytes,2,rep,name=changes,proto3" json:"changes,omitempty"`
+	SnapshotPath []string               `protobuf:"bytes,3,rep,name=snapshotPath,proto3" json:"snapshotPath,omitempty"`
+	// probe asks the responder for the tree's root and current heads only,
+	// with no change bodies. Old responders ignore it and stream the full
+	// tree; a probing requester must be ready for both response shapes.
+	Probe         bool `protobuf:"varint,4,opt,name=probe,proto3" json:"probe,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -860,6 +864,13 @@ func (x *TreeFullSyncRequest) GetSnapshotPath() []string {
 		return x.SnapshotPath
 	}
 	return nil
+}
+
+func (x *TreeFullSyncRequest) GetProbe() bool {
+	if x != nil {
+		return x.Probe
+	}
+	return false
 }
 
 // TreeFullSyncResponse is a message sent as a response for a specific full sync
@@ -1096,11 +1107,12 @@ const file_treechange_proto_rawDesc = "" +
 	"\x0eTreeHeadUpdate\x12\x14\n" +
 	"\x05heads\x18\x01 \x03(\tR\x05heads\x129\n" +
 	"\achanges\x18\x02 \x03(\v2\x1f.treechange.RawTreeChangeWithIdR\achanges\x12\"\n" +
-	"\fsnapshotPath\x18\x03 \x03(\tR\fsnapshotPath\"\x8a\x01\n" +
+	"\fsnapshotPath\x18\x03 \x03(\tR\fsnapshotPath\"\xa0\x01\n" +
 	"\x13TreeFullSyncRequest\x12\x14\n" +
 	"\x05heads\x18\x01 \x03(\tR\x05heads\x129\n" +
 	"\achanges\x18\x02 \x03(\v2\x1f.treechange.RawTreeChangeWithIdR\achanges\x12\"\n" +
-	"\fsnapshotPath\x18\x03 \x03(\tR\fsnapshotPath\"\x8b\x01\n" +
+	"\fsnapshotPath\x18\x03 \x03(\tR\fsnapshotPath\x12\x14\n" +
+	"\x05probe\x18\x04 \x01(\bR\x05probe\"\x8b\x01\n" +
 	"\x14TreeFullSyncResponse\x12\x14\n" +
 	"\x05heads\x18\x01 \x03(\tR\x05heads\x129\n" +
 	"\achanges\x18\x02 \x03(\v2\x1f.treechange.RawTreeChangeWithIdR\achanges\x12\"\n" +

--- a/commonspace/object/tree/treechangeproto/treechange_vtproto.pb.go
+++ b/commonspace/object/tree/treechangeproto/treechange_vtproto.pb.go
@@ -706,6 +706,16 @@ func (m *TreeFullSyncRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Probe {
+		i--
+		if m.Probe {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
 	if len(m.SnapshotPath) > 0 {
 		for iNdEx := len(m.SnapshotPath) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.SnapshotPath[iNdEx])
@@ -1208,6 +1218,9 @@ func (m *TreeFullSyncRequest) SizeVT() (n int) {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.Probe {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -3131,6 +3144,26 @@ func (m *TreeFullSyncRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.SnapshotPath = append(m.SnapshotPath, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Probe", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Probe = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/commonspace/object/treesyncer/treesyncer.go
+++ b/commonspace/object/treesyncer/treesyncer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/anyproto/any-sync/app"
+	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
 	"github.com/anyproto/any-sync/net/peer"
 )
 
@@ -16,4 +17,15 @@ type TreeSyncer interface {
 	StopSync()
 	ShouldSync(peerId string) bool
 	SyncAll(ctx context.Context, p peer.Peer, existing, missing []string) error
+}
+
+// PullFilter is an optional extension of the registered TreeSyncer. When a
+// head update arrives for a tree that does not exist locally, objectsync
+// consults it before queueing the fetch: returning false swallows the update
+// and the tree is not pulled. rootChange is the tree's raw root (carried by
+// every head update; its header — including changeType — is cleartext) and
+// heads are the sender's current heads. TreeSyncers that do not implement
+// the interface keep the default always-pull behavior.
+type PullFilter interface {
+	ShouldPull(ctx context.Context, objectId string, rootChange *treechangeproto.RawTreeChangeWithId, heads []string) bool
 }

--- a/commonspace/objecttreebuilder/treebuilder.go
+++ b/commonspace/objecttreebuilder/treebuilder.go
@@ -30,6 +30,10 @@ type BuildTreeOpts struct {
 	Listener      updatelistener.UpdateListener
 	TreeBuilder   objecttree.BuildObjectTreeFunc
 	TreeValidator objecttree.ValidatorFunc
+	// Probe requests the tree's root and current heads only (no change
+	// bodies) when the tree is fetched remotely. Requires a TreeValidator
+	// that inspects the payload and aborts — see synctree.BuildDeps.Probe.
+	Probe bool
 }
 
 const CName = "common.commonspace.objecttreebuilder"
@@ -155,6 +159,7 @@ func (t *treeBuilder) BuildTree(ctx context.Context, id string, opts BuildTreeOp
 		BuildObjectTree:    treeBuilder,
 		ValidateObjectTree: opts.TreeValidator,
 		StatsCollector:     t.treeStats,
+		Probe:              opts.Probe,
 	}
 	t.treesUsed.Add(1)
 	t.log.Debug("incrementing counter", zap.String("id", id), zap.Int32("trees", t.treesUsed.Load()))

--- a/commonspace/sync/objectsync/objectsync_test.go
+++ b/commonspace/sync/objectsync/objectsync_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/object/tree/synctree"
 	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
 	"github.com/anyproto/any-sync/commonspace/object/treemanager"
+	"github.com/anyproto/any-sync/commonspace/object/treesyncer"
 	"github.com/anyproto/any-sync/commonspace/objectmanager/mock_objectmanager"
 	"github.com/anyproto/any-sync/commonspace/spacestate"
 	"github.com/anyproto/any-sync/commonspace/sync/objectsync/objectmessages"
@@ -79,6 +80,85 @@ func TestObjectSync_HandleHeadUpdate(t *testing.T) {
 		req := synctree.NewRequest(update.Meta.PeerId, update.Meta.SpaceId, update.Meta.ObjectId, nil, nil, nil)
 		require.Equal(t, req, r)
 	})
+	t.Run("handle head update object missing, pull filter declines, update swallowed", func(t *testing.T) {
+		root := &treechangeproto.RawTreeChangeWithId{
+			RawChange: []byte("rootChange"),
+			Id:        "objectId",
+		}
+		var gotRoot *treechangeproto.RawTreeChangeWithId
+		var gotHeads []string
+		fx := newFixtureWithPullFilter(t, func(_ context.Context, objectId string, rootChange *treechangeproto.RawTreeChangeWithId, heads []string) bool {
+			require.Equal(t, "objectId", objectId)
+			gotRoot = rootChange
+			gotHeads = heads
+			return false
+		})
+		defer fx.close(t)
+		update := headUpdateWithRoot(t, root, []string{"headId"})
+		ctx = peer.CtxWithPeerId(ctx, "peerId")
+		fx.objectManager.EXPECT().GetObject(context.Background(), "objectId").Return(nil, fmt.Errorf("no object"))
+		r, err := fx.objectSync.HandleHeadUpdate(ctx, update)
+		require.NoError(t, err)
+		require.Nil(t, r)
+		require.Equal(t, root.Id, gotRoot.Id)
+		require.Equal(t, root.RawChange, gotRoot.RawChange)
+		require.Equal(t, []string{"headId"}, gotHeads)
+	})
+	t.Run("handle head update object missing, pull filter accepts, return request", func(t *testing.T) {
+		root := &treechangeproto.RawTreeChangeWithId{
+			RawChange: []byte("rootChange"),
+			Id:        "objectId",
+		}
+		fx := newFixtureWithPullFilter(t, func(_ context.Context, _ string, _ *treechangeproto.RawTreeChangeWithId, _ []string) bool {
+			return true
+		})
+		defer fx.close(t)
+		update := headUpdateWithRoot(t, root, []string{"headId"})
+		ctx = peer.CtxWithPeerId(ctx, "peerId")
+		fx.objectManager.EXPECT().GetObject(context.Background(), "objectId").Return(nil, fmt.Errorf("no object"))
+		r, err := fx.objectSync.HandleHeadUpdate(ctx, update)
+		require.NoError(t, err)
+		req := synctree.NewRequest("peerId", "spaceId", "objectId", nil, nil, nil)
+		require.Equal(t, req, r)
+	})
+	t.Run("handle head update object missing, no root in update, pull filter skipped, return request", func(t *testing.T) {
+		fx := newFixtureWithPullFilter(t, func(_ context.Context, _ string, _ *treechangeproto.RawTreeChangeWithId, _ []string) bool {
+			require.Fail(t, "filter must not be consulted without a root change")
+			return false
+		})
+		defer fx.close(t)
+		update := &objectmessages.HeadUpdate{
+			Meta: objectmessages.ObjectMeta{
+				PeerId:   "peerId",
+				ObjectId: "objectId",
+				SpaceId:  "spaceId",
+			},
+		}
+		ctx = peer.CtxWithPeerId(ctx, "peerId")
+		fx.objectManager.EXPECT().GetObject(context.Background(), "objectId").Return(nil, fmt.Errorf("no object"))
+		r, err := fx.objectSync.HandleHeadUpdate(ctx, update)
+		require.NoError(t, err)
+		req := synctree.NewRequest("peerId", "spaceId", "objectId", nil, nil, nil)
+		require.Equal(t, req, r)
+	})
+}
+
+func headUpdateWithRoot(t *testing.T, root *treechangeproto.RawTreeChangeWithId, heads []string) *objectmessages.HeadUpdate {
+	treeHeadUpdate := &treechangeproto.TreeHeadUpdate{
+		Heads:        heads,
+		SnapshotPath: []string{root.Id},
+	}
+	wrapped := treechangeproto.WrapHeadUpdate(treeHeadUpdate, root)
+	marshaled, err := wrapped.MarshalVT()
+	require.NoError(t, err)
+	return &objectmessages.HeadUpdate{
+		Bytes: marshaled,
+		Meta: objectmessages.ObjectMeta{
+			PeerId:   "peerId",
+			ObjectId: "objectId",
+			SpaceId:  "spaceId",
+		},
+	}
 }
 
 func TestObjectSync_HandleStreamRequest(t *testing.T) {
@@ -168,6 +248,31 @@ type fixture struct {
 }
 
 func newFixture(t *testing.T) *fixture {
+	return newFixtureWithPullFilter(t, nil)
+}
+
+// filteringTreeSyncer is a minimal TreeSyncer that also implements the
+// optional treesyncer.PullFilter extension.
+type filteringTreeSyncer struct {
+	shouldPull func(ctx context.Context, objectId string, rootChange *treechangeproto.RawTreeChangeWithId, heads []string) bool
+}
+
+func (f *filteringTreeSyncer) Init(a *app.App) error           { return nil }
+func (f *filteringTreeSyncer) Name() string                    { return treesyncer.CName }
+func (f *filteringTreeSyncer) Run(ctx context.Context) error   { return nil }
+func (f *filteringTreeSyncer) Close(ctx context.Context) error { return nil }
+func (f *filteringTreeSyncer) StartSync()                      {}
+func (f *filteringTreeSyncer) StopSync()                       {}
+func (f *filteringTreeSyncer) ShouldSync(string) bool          { return true }
+func (f *filteringTreeSyncer) SyncAll(ctx context.Context, p peer.Peer, existing, missing []string) error {
+	return nil
+}
+
+func (f *filteringTreeSyncer) ShouldPull(ctx context.Context, objectId string, rootChange *treechangeproto.RawTreeChangeWithId, heads []string) bool {
+	return f.shouldPull(ctx, objectId, rootChange, heads)
+}
+
+func newFixtureWithPullFilter(t *testing.T, shouldPull func(ctx context.Context, objectId string, rootChange *treechangeproto.RawTreeChangeWithId, heads []string) bool) *fixture {
 	fx := &fixture{
 		a: &app.App{},
 	}
@@ -186,6 +291,9 @@ func newFixture(t *testing.T) *fixture {
 		Register(fx.keyValue).
 		Register(syncstatus.NewNoOpSyncStatus()).
 		Register(fx.objectSync)
+	if shouldPull != nil {
+		fx.a.Register(&filteringTreeSyncer{shouldPull: shouldPull})
+	}
 	require.NoError(t, fx.a.Start(context.Background()))
 	return fx
 }

--- a/commonspace/sync/objectsync/synchandler.go
+++ b/commonspace/sync/objectsync/synchandler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/object/tree/synctree"
 	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
 	"github.com/anyproto/any-sync/commonspace/object/treemanager"
+	"github.com/anyproto/any-sync/commonspace/object/treesyncer"
 	"github.com/anyproto/any-sync/commonspace/objectmanager"
 	"github.com/anyproto/any-sync/commonspace/spacestate"
 	"github.com/anyproto/any-sync/commonspace/spacesyncproto"
@@ -31,11 +32,12 @@ var ErrUnexpectedHeadUpdateType = errors.New("unexpected head update type")
 var log = logger.NewNamed(syncdeps.CName)
 
 type objectSync struct {
-	spaceId  string
-	pool     pool.Service
-	manager  objectmanager.ObjectManager
-	status   syncstatus.StatusUpdater
-	keyValue kvinterfaces.KeyValueService
+	spaceId    string
+	pool       pool.Service
+	manager    objectmanager.ObjectManager
+	status     syncstatus.StatusUpdater
+	keyValue   kvinterfaces.KeyValueService
+	pullFilter treesyncer.PullFilter
 }
 
 func New() syncdeps.SyncHandler {
@@ -48,6 +50,8 @@ func (o *objectSync) Init(a *app.App) (err error) {
 	o.keyValue = a.MustComponent(kvinterfaces.CName).(kvinterfaces.KeyValueService)
 	o.status = a.MustComponent(syncstatus.CName).(syncstatus.StatusUpdater)
 	o.spaceId = a.MustComponent(spacestate.CName).(*spacestate.SpaceState).SpaceId
+	// optional extension of the registered tree syncer
+	o.pullFilter, _ = a.Component(treesyncer.CName).(treesyncer.PullFilter)
 	return
 }
 
@@ -69,6 +73,9 @@ func (o *objectSync) HandleHeadUpdate(ctx context.Context, headUpdate drpc.Messa
 	}
 	obj, err := o.manager.GetObject(context.Background(), update.Meta.ObjectId)
 	if err != nil {
+		if o.pullFilter != nil && !o.shouldPull(ctx, update) {
+			return nil, nil
+		}
 		return synctree.NewRequest(peerId, update.Meta.SpaceId, update.Meta.ObjectId, nil, nil, nil), nil
 	}
 	objHandler, ok := obj.(syncdeps.ObjectSyncHandler)
@@ -76,6 +83,21 @@ func (o *objectSync) HandleHeadUpdate(ctx context.Context, headUpdate drpc.Messa
 		return nil, fmt.Errorf("object %s does not support sync", obj.Id())
 	}
 	return objHandler.HandleHeadUpdate(ctx, o.status, update)
+}
+
+// shouldPull consults the pull filter for a locally-missing tree. Head
+// updates carry the tree's raw root change, so the filter can classify the
+// tree without fetching anything. Malformed updates default to pull.
+func (o *objectSync) shouldPull(ctx context.Context, update *objectmessages.HeadUpdate) bool {
+	treeSyncMsg := &treechangeproto.TreeSyncMessage{}
+	if err := treeSyncMsg.UnmarshalVT(update.Bytes); err != nil {
+		return true
+	}
+	contentUpdate := treeSyncMsg.GetContent().GetHeadUpdate()
+	if contentUpdate == nil || treeSyncMsg.RootChange == nil {
+		return true
+	}
+	return o.pullFilter.ShouldPull(ctx, update.Meta.ObjectId, treeSyncMsg.RootChange, contentUpdate.Heads)
 }
 
 func (o *objectSync) HandleStreamRequest(ctx context.Context, rq syncdeps.Request, updater syncdeps.QueueSizeUpdater, sendResponse func(resp proto.Message) error) (syncdeps.Request, error) {


### PR DESCRIPTION
Two opt-in, backward-compatible hooks enabling participants that head-sync a whole space but download + materialize only selected tree types (the filenode-v2 broker embedding the SDK — see [SYN-18](https://linear.app/anyorg/issue/SYN-18)). With neither hook used, behavior is byte-for-byte unchanged.

## `TreeFullSyncRequest.probe` (field 4)

A probe asks the responder for the tree's **root + current heads only** — no change bodies. The tree id is the root change's cid and `RootChange.changeType` is cleartext, so one probe is enough for a client to classify a tree without downloading it.

- Responder (`synctree.HandleStreamRequest`): replies with the empty-response shape (root, heads, snapshotPath) and sends no counter-request — a probe declares nothing about the requester's state.
- Requester: plumbed via `BuildTreeOpts.Probe` → `BuildDeps.Probe` → `treeRemoteGetter`; no `SyncClient` / `RequestFactory` interface changes.
- Compat: old responders ignore the flag and stream the full tree — a probing client must handle both shapes (the SDK aborts after the first batch via its `TreeValidator`). Old clients never set the flag.

## `treesyncer.PullFilter` (optional interface)

Every head update already carries the raw root change. When one arrives for a tree that doesn't exist locally, `objectsync.HandleHeadUpdate` now consults an optional `PullFilter` extension on the registered treesyncer component before queueing the fetch; returning `false` swallows the update. This lets a selective client classify the tree and record its new heads with **zero** extra round trips.

- Discovered by type assertion on the `treesyncer.CName` component — existing `TreeSyncer` implementations (anytype-heart, any-sync-node) compile and behave unchanged.
- Malformed / root-less updates bypass the filter and pull as before; the fetch path's validation stays authoritative.

## Tests

- probe responder returns root + heads with no changes and no counter-request; probe request marshal round-trip; `treeRemoteGetter` sends a probe when `BuildDeps.Probe` is set
- `PullFilter` declining swallows the update (root + heads delivered to the filter); accepting or missing-root updates keep the current request path; absent filter ⇒ unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)