### PR TITLE
feat(fileprotov2): NotResponsible error codes + node-level Info RPC (SYN-31)

### DIFF
--- a/commonfile/fileproto/fileprotov2/fileprotov2err/fileprotov2err.go
+++ b/commonfile/fileproto/fileprotov2/fileprotov2err/fileprotov2err.go
@@ -18,6 +18,7 @@ var (
 	ErrForbidden         = errGroup.Register(fmt.Errorf("forbidden"), uint64(fileprotov2.ErrCodes_Forbidden))
 	ErrInvalidRequest    = errGroup.Register(fmt.Errorf("invalid request"), uint64(fileprotov2.ErrCodes_InvalidRequest))
 	ErrQuerySizeExceeded = errGroup.Register(fmt.Errorf("query size exceeded"), uint64(fileprotov2.ErrCodes_QuerySizeExceeded))
+	ErrNotResponsible    = errGroup.Register(fmt.Errorf("node is not responsible for the space"), uint64(fileprotov2.ErrCodes_NotResponsible))
 )
 
 // FromCode maps a whole-RPC ErrCodes value to its registered drpc error so
@@ -31,6 +32,8 @@ func FromCode(code fileprotov2.ErrCodes) error {
 		return ErrInvalidRequest
 	case fileprotov2.ErrCodes_QuerySizeExceeded:
 		return ErrQuerySizeExceeded
+	case fileprotov2.ErrCodes_NotResponsible:
+		return ErrNotResponsible
 	default:
 		return ErrUnexpected
 	}

--- a/commonfile/fileproto/fileprotov2/filev2.pb.go
+++ b/commonfile/fileproto/fileprotov2/filev2.pb.go
@@ -1135,6 +1135,91 @@ func (x *SpaceQuota) GetFilesCount() uint64 {
 	return 0
 }
 
+// InfoRequest is deliberately empty: Info is static node metadata,
+// extensible later (capabilities, limits) without a wire break.
+type InfoRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InfoRequest) Reset() {
+	*x = InfoRequest{}
+	mi := &file_commonfile_fileproto_fileprotov2_protos_filev2_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InfoRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InfoRequest) ProtoMessage() {}
+
+func (x *InfoRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_commonfile_fileproto_fileprotov2_protos_filev2_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InfoRequest.ProtoReflect.Descriptor instead.
+func (*InfoRequest) Descriptor() ([]byte, []int) {
+	return file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDescGZIP(), []int{18}
+}
+
+type InfoResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// publicReadBaseUrl, when non-empty, lets clients construct durable object
+	// URLs as {publicReadBaseUrl}/blob/{spaceId}/{rootCid} with zero broker
+	// round-trips; clients cache it. Empty = no public read: use RequestDownload.
+	PublicReadBaseUrl string `protobuf:"bytes,1,opt,name=publicReadBaseUrl,proto3" json:"publicReadBaseUrl,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *InfoResponse) Reset() {
+	*x = InfoResponse{}
+	mi := &file_commonfile_fileproto_fileprotov2_protos_filev2_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InfoResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InfoResponse) ProtoMessage() {}
+
+func (x *InfoResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_commonfile_fileproto_fileprotov2_protos_filev2_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InfoResponse.ProtoReflect.Descriptor instead.
+func (*InfoResponse) Descriptor() ([]byte, []int) {
+	return file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *InfoResponse) GetPublicReadBaseUrl() string {
+	if x != nil {
+		return x.PublicReadBaseUrl
+	}
+	return ""
+}
+
 var File_commonfile_fileproto_fileprotov2_protos_filev2_proto protoreflect.FileDescriptor
 
 const file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDesc = "" +
@@ -1203,7 +1288,10 @@ const file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDesc = "" +
 	"\x12inflightUsageBytes\x18\x04 \x01(\x04R\x12inflightUsageBytes\x12\x1e\n" +
 	"\n" +
 	"filesCount\x18\x05 \x01(\x04R\n" +
-	"filesCount*z\n" +
+	"filesCount\"\r\n" +
+	"\vInfoRequest\"<\n" +
+	"\fInfoResponse\x12,\n" +
+	"\x11publicReadBaseUrl\x18\x01 \x01(\tR\x11publicReadBaseUrl*z\n" +
 	"\bErrCodes\x12\x0e\n" +
 	"\n" +
 	"Unexpected\x10\x00\x12\r\n" +
@@ -1219,12 +1307,13 @@ const file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDesc = "" +
 	"\fErrForbidden\x10\x03\x12\x14\n" +
 	"\x10ErrLimitExceeded\x10\x04\x12\x14\n" +
 	"\x10ErrSpaceNotFound\x10\x05\x12\x15\n" +
-	"\x11ErrNotResponsible\x10\x062\xbf\x02\n" +
+	"\x11ErrNotResponsible\x10\x062\xfa\x02\n" +
 	"\x06FileV2\x12?\n" +
 	"\x06Upload\x12\x19.filesyncv2.UploadRequest\x1a\x1a.filesyncv2.UploadResponse\x12N\n" +
 	"\vRequestSign\x12\x1e.filesyncv2.RequestSignRequest\x1a\x1f.filesyncv2.RequestSignResponse\x12Z\n" +
 	"\x0fRequestDownload\x12\".filesyncv2.RequestDownloadRequest\x1a#.filesyncv2.RequestDownloadResponse\x12H\n" +
-	"\tSpaceInfo\x12\x1c.filesyncv2.SpaceInfoRequest\x1a\x1d.filesyncv2.SpaceInfoResponseB\"Z commonfile/fileproto/fileprotov2b\x06proto3"
+	"\tSpaceInfo\x12\x1c.filesyncv2.SpaceInfoRequest\x1a\x1d.filesyncv2.SpaceInfoResponse\x129\n" +
+	"\x04Info\x12\x17.filesyncv2.InfoRequest\x1a\x18.filesyncv2.InfoResponseB\"Z commonfile/fileproto/fileprotov2b\x06proto3"
 
 var (
 	file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDescOnce sync.Once
@@ -1239,7 +1328,7 @@ func file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDescGZIP() []b
 }
 
 var file_commonfile_fileproto_fileprotov2_protos_filev2_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_commonfile_fileproto_fileprotov2_protos_filev2_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_commonfile_fileproto_fileprotov2_protos_filev2_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_commonfile_fileproto_fileprotov2_protos_filev2_proto_goTypes = []any{
 	(ErrCodes)(0),                   // 0: filesyncv2.ErrCodes
 	(ErrCode)(0),                    // 1: filesyncv2.ErrCode
@@ -1261,6 +1350,8 @@ var file_commonfile_fileproto_fileprotov2_protos_filev2_proto_goTypes = []any{
 	(*SpaceInfoResponse)(nil),       // 17: filesyncv2.SpaceInfoResponse
 	(*SpaceInfoResult)(nil),         // 18: filesyncv2.SpaceInfoResult
 	(*SpaceQuota)(nil),              // 19: filesyncv2.SpaceQuota
+	(*InfoRequest)(nil),             // 20: filesyncv2.InfoRequest
+	(*InfoResponse)(nil),            // 21: filesyncv2.InfoResponse
 }
 var file_commonfile_fileproto_fileprotov2_protos_filev2_proto_depIdxs = []int32{
 	3,  // 0: filesyncv2.UploadRequest.items:type_name -> filesyncv2.UploadRequestItem
@@ -1281,12 +1372,14 @@ var file_commonfile_fileproto_fileprotov2_protos_filev2_proto_depIdxs = []int32{
 	8,  // 15: filesyncv2.FileV2.RequestSign:input_type -> filesyncv2.RequestSignRequest
 	12, // 16: filesyncv2.FileV2.RequestDownload:input_type -> filesyncv2.RequestDownloadRequest
 	16, // 17: filesyncv2.FileV2.SpaceInfo:input_type -> filesyncv2.SpaceInfoRequest
-	4,  // 18: filesyncv2.FileV2.Upload:output_type -> filesyncv2.UploadResponse
-	9,  // 19: filesyncv2.FileV2.RequestSign:output_type -> filesyncv2.RequestSignResponse
-	13, // 20: filesyncv2.FileV2.RequestDownload:output_type -> filesyncv2.RequestDownloadResponse
-	17, // 21: filesyncv2.FileV2.SpaceInfo:output_type -> filesyncv2.SpaceInfoResponse
-	18, // [18:22] is the sub-list for method output_type
-	14, // [14:18] is the sub-list for method input_type
+	20, // 18: filesyncv2.FileV2.Info:input_type -> filesyncv2.InfoRequest
+	4,  // 19: filesyncv2.FileV2.Upload:output_type -> filesyncv2.UploadResponse
+	9,  // 20: filesyncv2.FileV2.RequestSign:output_type -> filesyncv2.RequestSignResponse
+	13, // 21: filesyncv2.FileV2.RequestDownload:output_type -> filesyncv2.RequestDownloadResponse
+	17, // 22: filesyncv2.FileV2.SpaceInfo:output_type -> filesyncv2.SpaceInfoResponse
+	21, // 23: filesyncv2.FileV2.Info:output_type -> filesyncv2.InfoResponse
+	19, // [19:24] is the sub-list for method output_type
+	14, // [14:19] is the sub-list for method input_type
 	14, // [14:14] is the sub-list for extension type_name
 	14, // [14:14] is the sub-list for extension extendee
 	0,  // [0:14] is the sub-list for field type_name
@@ -1303,7 +1396,7 @@ func file_commonfile_fileproto_fileprotov2_protos_filev2_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDesc), len(file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   18,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/commonfile/fileproto/fileprotov2/filev2.pb.go
+++ b/commonfile/fileproto/fileprotov2/filev2.pb.go
@@ -24,11 +24,11 @@ const (
 // ErrCodes are WHOLE-RPC (drpc-level) errors, mirroring v1 filesync.ErrCodes.
 // Wired through rpcerr.ErrGroup(ErrCodes_ErrorOffset) in the fileprotov2err
 // package. Returned as a NON-nil drpc error ONLY for auth / malformed /
-// batch-too-large. Never used to report the outcome of an individual item
-// (that is the per-item ErrCode below). Zero value Unexpected=0 registers at
-// offset+0 (=800), so an uncoded server fault reads as Unexpected — exactly as
-// v1 does at 200. Offset 800 is the only free rpcerr block (v1=200, 100/300/
-// 400/500/600/700 are taken).
+// batch-too-large / misrouted. Never used to report the outcome of an
+// individual item (that is the per-item ErrCode below). Zero value
+// Unexpected=0 registers at offset+0 (=800), so an uncoded server fault reads
+// as Unexpected — exactly as v1 does at 200. Offset 800 is the only free
+// rpcerr block (v1=200, 100/300/400/500/600/700 are taken).
 type ErrCodes int32
 
 const (
@@ -36,6 +36,7 @@ const (
 	ErrCodes_Forbidden         ErrCodes = 1   // connection identity is not permitted at all
 	ErrCodes_InvalidRequest    ErrCodes = 2   // malformed: empty spaceId, empty items, bad rootCid bytes
 	ErrCodes_QuerySizeExceeded ErrCodes = 3   // batch too large (too many items in one request)
+	ErrCodes_NotResponsible    ErrCodes = 4   // retryable routing signal: this node is not in the space's chash pair
 	ErrCodes_ErrorOffset       ErrCodes = 800 // rpcerr.ErrGroup base for v2 (constant, never an error)
 )
 
@@ -46,6 +47,7 @@ var (
 		1:   "Forbidden",
 		2:   "InvalidRequest",
 		3:   "QuerySizeExceeded",
+		4:   "NotResponsible",
 		800: "ErrorOffset",
 	}
 	ErrCodes_value = map[string]int32{
@@ -53,6 +55,7 @@ var (
 		"Forbidden":         1,
 		"InvalidRequest":    2,
 		"QuerySizeExceeded": 3,
+		"NotResponsible":    4,
 		"ErrorOffset":       800,
 	}
 )
@@ -95,12 +98,13 @@ func (ErrCodes) EnumDescriptor() ([]byte, []int) {
 type ErrCode int32
 
 const (
-	ErrCode_Ok               ErrCode = 0 // item succeeded; the typed payload is populated
-	ErrCode_ErrUnexpected    ErrCode = 1 // internal error handling this single item
-	ErrCode_ErrCidNotFound   ErrCode = 2 // sign/download: no such stored file for this rootCid
-	ErrCode_ErrForbidden     ErrCode = 3 // identity may not access this item's space/file
-	ErrCode_ErrLimitExceeded ErrCode = 4 // upload rejected: space/account storage limit reached
-	ErrCode_ErrSpaceNotFound ErrCode = 5 // quota-info: unknown/deleted space id
+	ErrCode_Ok                ErrCode = 0 // item succeeded; the typed payload is populated
+	ErrCode_ErrUnexpected     ErrCode = 1 // internal error handling this single item
+	ErrCode_ErrCidNotFound    ErrCode = 2 // sign/download: no such stored file for this rootCid
+	ErrCode_ErrForbidden      ErrCode = 3 // identity may not access this item's space/file
+	ErrCode_ErrLimitExceeded  ErrCode = 4 // upload rejected: space/account storage limit reached
+	ErrCode_ErrSpaceNotFound  ErrCode = 5 // quota-info: unknown/deleted space id
+	ErrCode_ErrNotResponsible ErrCode = 6 // retryable routing signal: this node is not in this item's space chash pair
 )
 
 // Enum value maps for ErrCode.
@@ -112,14 +116,16 @@ var (
 		3: "ErrForbidden",
 		4: "ErrLimitExceeded",
 		5: "ErrSpaceNotFound",
+		6: "ErrNotResponsible",
 	}
 	ErrCode_value = map[string]int32{
-		"Ok":               0,
-		"ErrUnexpected":    1,
-		"ErrCidNotFound":   2,
-		"ErrForbidden":     3,
-		"ErrLimitExceeded": 4,
-		"ErrSpaceNotFound": 5,
+		"Ok":                0,
+		"ErrUnexpected":     1,
+		"ErrCidNotFound":    2,
+		"ErrForbidden":      3,
+		"ErrLimitExceeded":  4,
+		"ErrSpaceNotFound":  5,
+		"ErrNotResponsible": 6,
 	}
 )
 
@@ -1197,21 +1203,23 @@ const file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDesc = "" +
 	"\x12inflightUsageBytes\x18\x04 \x01(\x04R\x12inflightUsageBytes\x12\x1e\n" +
 	"\n" +
 	"filesCount\x18\x05 \x01(\x04R\n" +
-	"filesCount*f\n" +
+	"filesCount*z\n" +
 	"\bErrCodes\x12\x0e\n" +
 	"\n" +
 	"Unexpected\x10\x00\x12\r\n" +
 	"\tForbidden\x10\x01\x12\x12\n" +
 	"\x0eInvalidRequest\x10\x02\x12\x15\n" +
-	"\x11QuerySizeExceeded\x10\x03\x12\x10\n" +
-	"\vErrorOffset\x10\xa0\x06*v\n" +
+	"\x11QuerySizeExceeded\x10\x03\x12\x12\n" +
+	"\x0eNotResponsible\x10\x04\x12\x10\n" +
+	"\vErrorOffset\x10\xa0\x06*\x8d\x01\n" +
 	"\aErrCode\x12\x06\n" +
 	"\x02Ok\x10\x00\x12\x11\n" +
 	"\rErrUnexpected\x10\x01\x12\x12\n" +
 	"\x0eErrCidNotFound\x10\x02\x12\x10\n" +
 	"\fErrForbidden\x10\x03\x12\x14\n" +
 	"\x10ErrLimitExceeded\x10\x04\x12\x14\n" +
-	"\x10ErrSpaceNotFound\x10\x052\xbf\x02\n" +
+	"\x10ErrSpaceNotFound\x10\x05\x12\x15\n" +
+	"\x11ErrNotResponsible\x10\x062\xbf\x02\n" +
 	"\x06FileV2\x12?\n" +
 	"\x06Upload\x12\x19.filesyncv2.UploadRequest\x1a\x1a.filesyncv2.UploadResponse\x12N\n" +
 	"\vRequestSign\x12\x1e.filesyncv2.RequestSignRequest\x1a\x1f.filesyncv2.RequestSignResponse\x12Z\n" +

--- a/commonfile/fileproto/fileprotov2/filev2_drpc.pb.go
+++ b/commonfile/fileproto/fileprotov2/filev2_drpc.pb.go
@@ -37,6 +37,7 @@ type DRPCFileV2Client interface {
 	RequestSign(ctx context.Context, in *RequestSignRequest) (*RequestSignResponse, error)
 	RequestDownload(ctx context.Context, in *RequestDownloadRequest) (*RequestDownloadResponse, error)
 	SpaceInfo(ctx context.Context, in *SpaceInfoRequest) (*SpaceInfoResponse, error)
+	Info(ctx context.Context, in *InfoRequest) (*InfoResponse, error)
 }
 
 type drpcFileV2Client struct {
@@ -85,11 +86,21 @@ func (c *drpcFileV2Client) SpaceInfo(ctx context.Context, in *SpaceInfoRequest) 
 	return out, nil
 }
 
+func (c *drpcFileV2Client) Info(ctx context.Context, in *InfoRequest) (*InfoResponse, error) {
+	out := new(InfoResponse)
+	err := c.cc.Invoke(ctx, "/filesyncv2.FileV2/Info", drpcEncoding_File_commonfile_fileproto_fileprotov2_protos_filev2_proto{}, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 type DRPCFileV2Server interface {
 	Upload(context.Context, *UploadRequest) (*UploadResponse, error)
 	RequestSign(context.Context, *RequestSignRequest) (*RequestSignResponse, error)
 	RequestDownload(context.Context, *RequestDownloadRequest) (*RequestDownloadResponse, error)
 	SpaceInfo(context.Context, *SpaceInfoRequest) (*SpaceInfoResponse, error)
+	Info(context.Context, *InfoRequest) (*InfoResponse, error)
 }
 
 type DRPCFileV2UnimplementedServer struct{}
@@ -110,9 +121,13 @@ func (s *DRPCFileV2UnimplementedServer) SpaceInfo(context.Context, *SpaceInfoReq
 	return nil, drpcerr.WithCode(errors.New("Unimplemented"), drpcerr.Unimplemented)
 }
 
+func (s *DRPCFileV2UnimplementedServer) Info(context.Context, *InfoRequest) (*InfoResponse, error) {
+	return nil, drpcerr.WithCode(errors.New("Unimplemented"), drpcerr.Unimplemented)
+}
+
 type DRPCFileV2Description struct{}
 
-func (DRPCFileV2Description) NumMethods() int { return 4 }
+func (DRPCFileV2Description) NumMethods() int { return 5 }
 
 func (DRPCFileV2Description) Method(n int) (string, drpc.Encoding, drpc.Receiver, interface{}, bool) {
 	switch n {
@@ -152,6 +167,15 @@ func (DRPCFileV2Description) Method(n int) (string, drpc.Encoding, drpc.Receiver
 						in1.(*SpaceInfoRequest),
 					)
 			}, DRPCFileV2Server.SpaceInfo, true
+	case 4:
+		return "/filesyncv2.FileV2/Info", drpcEncoding_File_commonfile_fileproto_fileprotov2_protos_filev2_proto{},
+			func(srv interface{}, ctx context.Context, in1, in2 interface{}) (drpc.Message, error) {
+				return srv.(DRPCFileV2Server).
+					Info(
+						ctx,
+						in1.(*InfoRequest),
+					)
+			}, DRPCFileV2Server.Info, true
 	default:
 		return "", nil, nil, nil, false
 	}
@@ -219,6 +243,22 @@ type drpcFileV2_SpaceInfoStream struct {
 }
 
 func (x *drpcFileV2_SpaceInfoStream) SendAndClose(m *SpaceInfoResponse) error {
+	if err := x.MsgSend(m, drpcEncoding_File_commonfile_fileproto_fileprotov2_protos_filev2_proto{}); err != nil {
+		return err
+	}
+	return x.CloseSend()
+}
+
+type DRPCFileV2_InfoStream interface {
+	drpc.Stream
+	SendAndClose(*InfoResponse) error
+}
+
+type drpcFileV2_InfoStream struct {
+	drpc.Stream
+}
+
+func (x *drpcFileV2_InfoStream) SendAndClose(m *InfoResponse) error {
 	if err := x.MsgSend(m, drpcEncoding_File_commonfile_fileproto_fileprotov2_protos_filev2_proto{}); err != nil {
 		return err
 	}

--- a/commonfile/fileproto/fileprotov2/filev2_vtproto.pb.go
+++ b/commonfile/fileproto/fileprotov2/filev2_vtproto.pb.go
@@ -914,6 +914,79 @@ func (m *SpaceQuota) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *InfoRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *InfoRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *InfoRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *InfoResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *InfoResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *InfoResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.PublicReadBaseUrl) > 0 {
+		i -= len(m.PublicReadBaseUrl)
+		copy(dAtA[i:], m.PublicReadBaseUrl)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PublicReadBaseUrl)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *UploadRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1254,6 +1327,30 @@ func (m *SpaceQuota) SizeVT() (n int) {
 	}
 	if m.FilesCount != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.FilesCount))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *InfoRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *InfoResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.PublicReadBaseUrl)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -3306,6 +3403,140 @@ func (m *SpaceQuota) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *InfoRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: InfoRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: InfoRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *InfoResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: InfoResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: InfoResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PublicReadBaseUrl", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PublicReadBaseUrl = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/commonfile/fileproto/fileprotov2/protos/filev2.proto
+++ b/commonfile/fileproto/fileprotov2/protos/filev2.proto
@@ -26,8 +26,9 @@ option go_package = "commonfile/fileproto/fileprotov2";
 // Two error layers:
 //   1. whole-RPC drpc error (err != nil), carrying an ErrCodes value from the
 //      offset-800 rpcerr registry, returned ONLY for cross-cutting failures:
-//      failed/absent auth (Forbidden), malformed input (InvalidRequest), or an
-//      over-sized batch (QuerySizeExceeded);
+//      failed/absent auth (Forbidden), malformed input (InvalidRequest), an
+//      over-sized batch (QuerySizeExceeded), or a misrouted single-space
+//      request (NotResponsible — retry against the space's responsible pair);
 //   2. per-item business outcome lives in the in-body ErrCode `code` field
 //      (err == nil for the RPC as a whole).
 service FileV2 {
@@ -44,16 +45,17 @@ service FileV2 {
 // ErrCodes are WHOLE-RPC (drpc-level) errors, mirroring v1 filesync.ErrCodes.
 // Wired through rpcerr.ErrGroup(ErrCodes_ErrorOffset) in the fileprotov2err
 // package. Returned as a NON-nil drpc error ONLY for auth / malformed /
-// batch-too-large. Never used to report the outcome of an individual item
-// (that is the per-item ErrCode below). Zero value Unexpected=0 registers at
-// offset+0 (=800), so an uncoded server fault reads as Unexpected — exactly as
-// v1 does at 200. Offset 800 is the only free rpcerr block (v1=200, 100/300/
-// 400/500/600/700 are taken).
+// batch-too-large / misrouted. Never used to report the outcome of an
+// individual item (that is the per-item ErrCode below). Zero value
+// Unexpected=0 registers at offset+0 (=800), so an uncoded server fault reads
+// as Unexpected — exactly as v1 does at 200. Offset 800 is the only free
+// rpcerr block (v1=200, 100/300/400/500/600/700 are taken).
 enum ErrCodes {
     Unexpected = 0;         // unclassified server fault (registry fallback)
     Forbidden = 1;          // connection identity is not permitted at all
     InvalidRequest = 2;     // malformed: empty spaceId, empty items, bad rootCid bytes
     QuerySizeExceeded = 3;  // batch too large (too many items in one request)
+    NotResponsible = 4;     // retryable routing signal: this node is not in the space's chash pair
     ErrorOffset = 800;      // rpcerr.ErrGroup base for v2 (constant, never an error)
 }
 
@@ -72,6 +74,7 @@ enum ErrCode {
     ErrForbidden = 3;       // identity may not access this item's space/file
     ErrLimitExceeded = 4;   // upload rejected: space/account storage limit reached
     ErrSpaceNotFound = 5;   // quota-info: unknown/deleted space id
+    ErrNotResponsible = 6;  // retryable routing signal: this node is not in this item's space chash pair
 }
 
 // ---- Upload ---------------------------------------------------------------

--- a/commonfile/fileproto/fileprotov2/protos/filev2.proto
+++ b/commonfile/fileproto/fileprotov2/protos/filev2.proto
@@ -10,7 +10,7 @@ option go_package = "commonfile/fileproto/fileprotov2";
 // without a Register() panic. The package/service names are load-bearing:
 // method paths are derived from `package filesyncv2` + `service FileV2`.
 //
-// Conventions (ALL four RPCs are BATCH):
+// Conventions (all four SPACE-SCOPED RPCs are BATCH; Info is node-level):
 //   * request carries a single shared spaceId (or repeated spaceIds for
 //     SpaceInfo) + a repeated list of items;
 //   * identity is NEVER a request field — it is taken from the authenticated
@@ -40,6 +40,9 @@ service FileV2 {
     rpc RequestDownload(RequestDownloadRequest) returns (RequestDownloadResponse);
     // SpaceInfo returns quota/usage per requested space (batch quota-info).
     rpc SpaceInfo(SpaceInfoRequest) returns (SpaceInfoResponse);
+    // Info returns static node-level metadata (no spaceId, no responsibility
+    // gate, no auth beyond the connection); clients cache it.
+    rpc Info(InfoRequest) returns (InfoResponse);
 }
 
 // ErrCodes are WHOLE-RPC (drpc-level) errors, mirroring v1 filesync.ErrCodes.
@@ -188,4 +191,17 @@ message SpaceQuota {
     uint64 durableUsageBytes = 3;   // bytes fully committed to durable storage
     uint64 inflightUsageBytes = 4;  // bytes reserved by presigned/not-yet-committed uploads
     uint64 filesCount = 5;          // number of file roots stored in the space
+}
+
+// ---- Info (node-level metadata) ---------------------------------------------
+
+// InfoRequest is deliberately empty: Info is static node metadata,
+// extensible later (capabilities, limits) without a wire break.
+message InfoRequest {}
+
+message InfoResponse {
+    // publicReadBaseUrl, when non-empty, lets clients construct durable object
+    // URLs as {publicReadBaseUrl}/blob/{spaceId}/{rootCid} with zero broker
+    // round-trips; clients cache it. Empty = no public read: use RequestDownload.
+    string publicReadBaseUrl = 1;
 }


### PR DESCRIPTION
## What

Two additions to the FileV2 broker protocol:

### 1. NotResponsible routing codes

A dedicated, retryable routing signal for requests that land on a filenode outside the space's chash responsibility pair:

- **whole-RPC** `ErrCodes.NotResponsible = 4` — registered in `fileprotov2err` (rpcerr offset 800+4, `FromCode` case) — for the single-space RPCs (`Upload` / `RequestSign` / `RequestDownload`), where the entire request is misrouted and the client should re-route to the space's responsible pair;
- **per-item** `ErrCode.ErrNotResponsible = 6` — for `SpaceInfo`, whose batch may legally mix spaces owned by different pairs, so responsibility is a per-item outcome there.

Spaces chash-shard across the `NodeTypeFileV2` pool (RF=2); a filenode must reject — and never activate/sync — spaces it is not responsible for. Until now that gate had to surface as `Forbidden`, which clients cannot distinguish from an ACL denial and therefore cannot treat as "retry elsewhere".

### 2. Node-level `Info` RPC

Downloads start PUBLIC-read: chat-message images must render with zero broker round-trips, so the client constructs durable object URLs straight from the rootCid — `{publicReadBaseUrl}/blob/{spaceId}/{rootCid}` — and GETs the CDN. The base URL is distributed by the filenode itself (not nodeconf) via `Info`, which clients cache: no spaceId, no responsibility gate, no auth beyond the connection. `InfoRequest` is deliberately empty so future node metadata (capabilities, limits) extends it without a wire break; empty `publicReadBaseUrl` = no public read, use `RequestDownload`.

Generated code refreshed via the standard protoc/vtproto/drpc toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)