### PR TITLE
feat(coordinatorproto): files-v2 storage limits API — FileLimitsGet / FileUsageReport (SYN-19)

### DIFF
--- a/commonfile/fileproto/fileprotov2/filev2.pb.go
+++ b/commonfile/fileproto/fileprotov2/filev2.pb.go
@@ -1061,13 +1061,18 @@ func (x *SpaceInfoResult) GetQuota() *SpaceQuota {
 
 type SpaceQuota struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
-	LimitBytes         uint64                 `protobuf:"varint,1,opt,name=limitBytes,proto3" json:"limitBytes,omitempty"`                 // effective storage limit for this space
+	LimitBytes         uint64                 `protobuf:"varint,1,opt,name=limitBytes,proto3" json:"limitBytes,omitempty"`                 // effective storage limit for the requester in this space
 	TotalUsageBytes    uint64                 `protobuf:"varint,2,opt,name=totalUsageBytes,proto3" json:"totalUsageBytes,omitempty"`       // counted usage == durableUsageBytes + inflightUsageBytes
 	DurableUsageBytes  uint64                 `protobuf:"varint,3,opt,name=durableUsageBytes,proto3" json:"durableUsageBytes,omitempty"`   // bytes fully committed to durable storage
 	InflightUsageBytes uint64                 `protobuf:"varint,4,opt,name=inflightUsageBytes,proto3" json:"inflightUsageBytes,omitempty"` // bytes reserved by presigned/not-yet-committed uploads
 	FilesCount         uint64                 `protobuf:"varint,5,opt,name=filesCount,proto3" json:"filesCount,omitempty"`                 // number of file roots stored in the space
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// account-pool view for the requesting identity (files are charged to
+	// their uploader; all the identity's spaces share one pool). Zero when
+	// the node has no coordinator-backed limits (self-hosted fallback).
+	AccountLimitBytes uint64 `protobuf:"varint,6,opt,name=accountLimitBytes,proto3" json:"accountLimitBytes,omitempty"` // the identity's total file-storage cap
+	AccountUsageBytes uint64 `protobuf:"varint,7,opt,name=accountUsageBytes,proto3" json:"accountUsageBytes,omitempty"` // aggregated durable usage across the identity's spaces
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SpaceQuota) Reset() {
@@ -1131,6 +1136,20 @@ func (x *SpaceQuota) GetInflightUsageBytes() uint64 {
 func (x *SpaceQuota) GetFilesCount() uint64 {
 	if x != nil {
 		return x.FilesCount
+	}
+	return 0
+}
+
+func (x *SpaceQuota) GetAccountLimitBytes() uint64 {
+	if x != nil {
+		return x.AccountLimitBytes
+	}
+	return 0
+}
+
+func (x *SpaceQuota) GetAccountUsageBytes() uint64 {
+	if x != nil {
+		return x.AccountUsageBytes
 	}
 	return 0
 }
@@ -1277,7 +1296,7 @@ const file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDesc = "" +
 	"\x0fSpaceInfoResult\x12\x18\n" +
 	"\aspaceId\x18\x01 \x01(\tR\aspaceId\x12'\n" +
 	"\x04code\x18\x02 \x01(\x0e2\x13.filesyncv2.ErrCodeR\x04code\x12,\n" +
-	"\x05quota\x18\x03 \x01(\v2\x16.filesyncv2.SpaceQuotaR\x05quota\"\xd4\x01\n" +
+	"\x05quota\x18\x03 \x01(\v2\x16.filesyncv2.SpaceQuotaR\x05quota\"\xb0\x02\n" +
 	"\n" +
 	"SpaceQuota\x12\x1e\n" +
 	"\n" +
@@ -1288,7 +1307,9 @@ const file_commonfile_fileproto_fileprotov2_protos_filev2_proto_rawDesc = "" +
 	"\x12inflightUsageBytes\x18\x04 \x01(\x04R\x12inflightUsageBytes\x12\x1e\n" +
 	"\n" +
 	"filesCount\x18\x05 \x01(\x04R\n" +
-	"filesCount\"\r\n" +
+	"filesCount\x12,\n" +
+	"\x11accountLimitBytes\x18\x06 \x01(\x04R\x11accountLimitBytes\x12,\n" +
+	"\x11accountUsageBytes\x18\a \x01(\x04R\x11accountUsageBytes\"\r\n" +
 	"\vInfoRequest\"<\n" +
 	"\fInfoResponse\x12,\n" +
 	"\x11publicReadBaseUrl\x18\x01 \x01(\tR\x11publicReadBaseUrl*z\n" +

--- a/commonfile/fileproto/fileprotov2/filev2_vtproto.pb.go
+++ b/commonfile/fileproto/fileprotov2/filev2_vtproto.pb.go
@@ -886,6 +886,16 @@ func (m *SpaceQuota) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.AccountUsageBytes != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.AccountUsageBytes))
+		i--
+		dAtA[i] = 0x38
+	}
+	if m.AccountLimitBytes != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.AccountLimitBytes))
+		i--
+		dAtA[i] = 0x30
+	}
 	if m.FilesCount != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FilesCount))
 		i--
@@ -1327,6 +1337,12 @@ func (m *SpaceQuota) SizeVT() (n int) {
 	}
 	if m.FilesCount != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.FilesCount))
+	}
+	if m.AccountLimitBytes != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.AccountLimitBytes))
+	}
+	if m.AccountUsageBytes != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.AccountUsageBytes))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -3399,6 +3415,44 @@ func (m *SpaceQuota) UnmarshalVT(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.FilesCount |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AccountLimitBytes", wireType)
+			}
+			m.AccountLimitBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.AccountLimitBytes |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AccountUsageBytes", wireType)
+			}
+			m.AccountUsageBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.AccountUsageBytes |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/commonfile/fileproto/fileprotov2/protos/filev2.proto
+++ b/commonfile/fileproto/fileprotov2/protos/filev2.proto
@@ -186,11 +186,16 @@ message SpaceInfoResult {
 }
 
 message SpaceQuota {
-    uint64 limitBytes = 1;          // effective storage limit for this space
+    uint64 limitBytes = 1;          // effective storage limit for the requester in this space
     uint64 totalUsageBytes = 2;     // counted usage == durableUsageBytes + inflightUsageBytes
     uint64 durableUsageBytes = 3;   // bytes fully committed to durable storage
     uint64 inflightUsageBytes = 4;  // bytes reserved by presigned/not-yet-committed uploads
     uint64 filesCount = 5;          // number of file roots stored in the space
+    // account-pool view for the requesting identity (files are charged to
+    // their uploader; all the identity's spaces share one pool). Zero when
+    // the node has no coordinator-backed limits (self-hosted fallback).
+    uint64 accountLimitBytes = 6;   // the identity's total file-storage cap
+    uint64 accountUsageBytes = 7;   // aggregated durable usage across the identity's spaces
 }
 
 // ---- Info (node-level metadata) ---------------------------------------------

--- a/coordinator/coordinatorclient/coordinatorclient.go
+++ b/coordinator/coordinatorclient/coordinatorclient.go
@@ -56,6 +56,9 @@ type CoordinatorClient interface {
 
 	AclUploadInvite(ctx context.Context, block blocks.Block) (err error)
 
+	FileLimitsGet(ctx context.Context, spaceId, identity string) (resp *coordinatorproto.FileLimitsGetResponse, err error)
+	FileUsageReport(ctx context.Context, rows []*coordinatorproto.FileUsageRow) (err error)
+
 	app.Component
 }
 
@@ -290,6 +293,29 @@ func (c *coordinatorClient) AclGetRecords(ctx context.Context, spaceId, aclHead 
 func (c *coordinatorClient) AccountLimitsSet(ctx context.Context, req *coordinatorproto.AccountLimitsSetRequest) error {
 	return c.doClient(ctx, func(cl coordinatorproto.DRPCCoordinatorClient) error {
 		if _, err := cl.AccountLimitsSet(ctx, req); err != nil {
+			return rpcerr.Unwrap(err)
+		}
+		return nil
+	})
+}
+
+func (c *coordinatorClient) FileLimitsGet(ctx context.Context, spaceId, identity string) (resp *coordinatorproto.FileLimitsGetResponse, err error) {
+	err = c.doClient(ctx, func(cl coordinatorproto.DRPCCoordinatorClient) error {
+		resp, err = cl.FileLimitsGet(ctx, &coordinatorproto.FileLimitsGetRequest{
+			SpaceId:  spaceId,
+			Identity: identity,
+		})
+		if err != nil {
+			return rpcerr.Unwrap(err)
+		}
+		return nil
+	})
+	return
+}
+
+func (c *coordinatorClient) FileUsageReport(ctx context.Context, rows []*coordinatorproto.FileUsageRow) (err error) {
+	return c.doClient(ctx, func(cl coordinatorproto.DRPCCoordinatorClient) error {
+		if _, err := cl.FileUsageReport(ctx, &coordinatorproto.FileUsageReportRequest{Rows: rows}); err != nil {
 			return rpcerr.Unwrap(err)
 		}
 		return nil

--- a/coordinator/coordinatorclient/mock_coordinatorclient/mock_coordinatorclient.go
+++ b/coordinator/coordinatorclient/mock_coordinatorclient/mock_coordinatorclient.go
@@ -163,6 +163,35 @@ func (mr *MockCoordinatorClientMockRecorder) DeletionLog(ctx, lastRecordId, limi
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletionLog", reflect.TypeOf((*MockCoordinatorClient)(nil).DeletionLog), ctx, lastRecordId, limit)
 }
 
+// FileLimitsGet mocks base method.
+func (m *MockCoordinatorClient) FileLimitsGet(ctx context.Context, spaceId, identity string) (*coordinatorproto.FileLimitsGetResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FileLimitsGet", ctx, spaceId, identity)
+	ret0, _ := ret[0].(*coordinatorproto.FileLimitsGetResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FileLimitsGet indicates an expected call of FileLimitsGet.
+func (mr *MockCoordinatorClientMockRecorder) FileLimitsGet(ctx, spaceId, identity any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileLimitsGet", reflect.TypeOf((*MockCoordinatorClient)(nil).FileLimitsGet), ctx, spaceId, identity)
+}
+
+// FileUsageReport mocks base method.
+func (m *MockCoordinatorClient) FileUsageReport(ctx context.Context, rows []*coordinatorproto.FileUsageRow) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FileUsageReport", ctx, rows)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FileUsageReport indicates an expected call of FileUsageReport.
+func (mr *MockCoordinatorClientMockRecorder) FileUsageReport(ctx, rows any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileUsageReport", reflect.TypeOf((*MockCoordinatorClient)(nil).FileUsageReport), ctx, rows)
+}
+
 // IdentityRepoGet mocks base method.
 func (m *MockCoordinatorClient) IdentityRepoGet(ctx context.Context, identities, kinds []string) ([]*identityrepoproto.DataWithIdentity, error) {
 	m.ctrl.T.Helper()

--- a/coordinator/coordinatorproto/coordinator.pb.go
+++ b/coordinator/coordinatorproto/coordinator.pb.go
@@ -3490,6 +3490,272 @@ func (*AclUploadInviteResponse) Descriptor() ([]byte, []int) {
 	return file_coordinator_coordinatorproto_protos_coordinator_proto_rawDescGZIP(), []int{51}
 }
 
+type FileLimitsGetRequest struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	SpaceId string                 `protobuf:"bytes,1,opt,name=spaceId,proto3" json:"spaceId,omitempty"`
+	// Identity is the uploader account identity whose pool bounds are requested
+	Identity      string `protobuf:"bytes,2,opt,name=identity,proto3" json:"identity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FileLimitsGetRequest) Reset() {
+	*x = FileLimitsGetRequest{}
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FileLimitsGetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FileLimitsGetRequest) ProtoMessage() {}
+
+func (x *FileLimitsGetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FileLimitsGetRequest.ProtoReflect.Descriptor instead.
+func (*FileLimitsGetRequest) Descriptor() ([]byte, []int) {
+	return file_coordinator_coordinatorproto_protos_coordinator_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *FileLimitsGetRequest) GetSpaceId() string {
+	if x != nil {
+		return x.SpaceId
+	}
+	return ""
+}
+
+func (x *FileLimitsGetRequest) GetIdentity() string {
+	if x != nil {
+		return x.Identity
+	}
+	return ""
+}
+
+type FileLimitsGetResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// AccountLimitBytes is the identity's total file-storage cap (the common account pool)
+	AccountLimitBytes uint64 `protobuf:"varint,1,opt,name=accountLimitBytes,proto3" json:"accountLimitBytes,omitempty"`
+	// AccountTotalUsageBytes is the coordinator-aggregated durable usage across all the identity's spaces
+	AccountTotalUsageBytes uint64 `protobuf:"varint,2,opt,name=accountTotalUsageBytes,proto3" json:"accountTotalUsageBytes,omitempty"`
+	// SpaceLimitBytes is an optional space-scoped cap; 0 = unset
+	SpaceLimitBytes uint64 `protobuf:"varint,3,opt,name=spaceLimitBytes,proto3" json:"spaceLimitBytes,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *FileLimitsGetResponse) Reset() {
+	*x = FileLimitsGetResponse{}
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FileLimitsGetResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FileLimitsGetResponse) ProtoMessage() {}
+
+func (x *FileLimitsGetResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FileLimitsGetResponse.ProtoReflect.Descriptor instead.
+func (*FileLimitsGetResponse) Descriptor() ([]byte, []int) {
+	return file_coordinator_coordinatorproto_protos_coordinator_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *FileLimitsGetResponse) GetAccountLimitBytes() uint64 {
+	if x != nil {
+		return x.AccountLimitBytes
+	}
+	return 0
+}
+
+func (x *FileLimitsGetResponse) GetAccountTotalUsageBytes() uint64 {
+	if x != nil {
+		return x.AccountTotalUsageBytes
+	}
+	return 0
+}
+
+func (x *FileLimitsGetResponse) GetSpaceLimitBytes() uint64 {
+	if x != nil {
+		return x.SpaceLimitBytes
+	}
+	return 0
+}
+
+type FileUsageReportRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Rows          []*FileUsageRow        `protobuf:"bytes,1,rep,name=rows,proto3" json:"rows,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FileUsageReportRequest) Reset() {
+	*x = FileUsageReportRequest{}
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FileUsageReportRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FileUsageReportRequest) ProtoMessage() {}
+
+func (x *FileUsageReportRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FileUsageReportRequest.ProtoReflect.Descriptor instead.
+func (*FileUsageReportRequest) Descriptor() ([]byte, []int) {
+	return file_coordinator_coordinatorproto_protos_coordinator_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *FileUsageReportRequest) GetRows() []*FileUsageRow {
+	if x != nil {
+		return x.Rows
+	}
+	return nil
+}
+
+type FileUsageRow struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	SpaceId string                 `protobuf:"bytes,1,opt,name=spaceId,proto3" json:"spaceId,omitempty"`
+	// Identity is the charged uploader identity (the author of the root's earliest bind row)
+	Identity string `protobuf:"bytes,2,opt,name=identity,proto3" json:"identity,omitempty"`
+	// DurableBytes is the HEAD-measured durable usage of this (space, identity) slice; in-flight is never reported
+	DurableBytes      uint64 `protobuf:"varint,3,opt,name=durableBytes,proto3" json:"durableBytes,omitempty"`
+	DurableFilesCount uint64 `protobuf:"varint,4,opt,name=durableFilesCount,proto3" json:"durableFilesCount,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *FileUsageRow) Reset() {
+	*x = FileUsageRow{}
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FileUsageRow) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FileUsageRow) ProtoMessage() {}
+
+func (x *FileUsageRow) ProtoReflect() protoreflect.Message {
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FileUsageRow.ProtoReflect.Descriptor instead.
+func (*FileUsageRow) Descriptor() ([]byte, []int) {
+	return file_coordinator_coordinatorproto_protos_coordinator_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *FileUsageRow) GetSpaceId() string {
+	if x != nil {
+		return x.SpaceId
+	}
+	return ""
+}
+
+func (x *FileUsageRow) GetIdentity() string {
+	if x != nil {
+		return x.Identity
+	}
+	return ""
+}
+
+func (x *FileUsageRow) GetDurableBytes() uint64 {
+	if x != nil {
+		return x.DurableBytes
+	}
+	return 0
+}
+
+func (x *FileUsageRow) GetDurableFilesCount() uint64 {
+	if x != nil {
+		return x.DurableFilesCount
+	}
+	return 0
+}
+
+type FileUsageReportResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FileUsageReportResponse) Reset() {
+	*x = FileUsageReportResponse{}
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FileUsageReportResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FileUsageReportResponse) ProtoMessage() {}
+
+func (x *FileUsageReportResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FileUsageReportResponse.ProtoReflect.Descriptor instead.
+func (*FileUsageReportResponse) Descriptor() ([]byte, []int) {
+	return file_coordinator_coordinatorproto_protos_coordinator_proto_rawDescGZIP(), []int{56}
+}
+
 var File_coordinator_coordinatorproto_protos_coordinator_proto protoreflect.FileDescriptor
 
 const file_coordinator_coordinatorproto_protos_coordinator_proto_rawDesc = "" +
@@ -3665,7 +3931,22 @@ const file_coordinator_coordinatorproto_protos_coordinator_proto_rawDesc = "" +
 	"\x16AclUploadInviteRequest\x12\x10\n" +
 	"\x03cid\x18\x01 \x01(\fR\x03cid\x12\x12\n" +
 	"\x04data\x18\x02 \x01(\fR\x04data\"\x19\n" +
-	"\x17AclUploadInviteResponse*\xba\x02\n" +
+	"\x17AclUploadInviteResponse\"L\n" +
+	"\x14FileLimitsGetRequest\x12\x18\n" +
+	"\aspaceId\x18\x01 \x01(\tR\aspaceId\x12\x1a\n" +
+	"\bidentity\x18\x02 \x01(\tR\bidentity\"\xa7\x01\n" +
+	"\x15FileLimitsGetResponse\x12,\n" +
+	"\x11accountLimitBytes\x18\x01 \x01(\x04R\x11accountLimitBytes\x126\n" +
+	"\x16accountTotalUsageBytes\x18\x02 \x01(\x04R\x16accountTotalUsageBytes\x12(\n" +
+	"\x0fspaceLimitBytes\x18\x03 \x01(\x04R\x0fspaceLimitBytes\"G\n" +
+	"\x16FileUsageReportRequest\x12-\n" +
+	"\x04rows\x18\x01 \x03(\v2\x19.coordinator.FileUsageRowR\x04rows\"\x96\x01\n" +
+	"\fFileUsageRow\x12\x18\n" +
+	"\aspaceId\x18\x01 \x01(\tR\aspaceId\x12\x1a\n" +
+	"\bidentity\x18\x02 \x01(\tR\bidentity\x12\"\n" +
+	"\fdurableBytes\x18\x03 \x01(\x04R\fdurableBytes\x12,\n" +
+	"\x11durableFilesCount\x18\x04 \x01(\x04R\x11durableFilesCount\"\x19\n" +
+	"\x17FileUsageReportResponse*\xba\x02\n" +
 	"\n" +
 	"ErrorCodes\x12\x0e\n" +
 	"\n" +
@@ -3726,7 +4007,7 @@ const file_coordinator_coordinatorproto_protos_coordinator_proto_rawDesc = "" +
 	"\x0fNotifyEventType\x12\x14\n" +
 	"\x10UnspecifiedEvent\x10\x00\x12\x18\n" +
 	"\x14InboxNewMessageEvent\x10\x01\x12\x1d\n" +
-	"\x19NetworkConfigChangedEvent\x10\x022\x80\x0e\n" +
+	"\x19NetworkConfigChangedEvent\x10\x022\xb6\x0f\n" +
 	"\vCoordinator\x12J\n" +
 	"\tSpaceSign\x12\x1d.coordinator.SpaceSignRequest\x1a\x1e.coordinator.SpaceSignResponse\x12_\n" +
 	"\x10SpaceStatusCheck\x12$.coordinator.SpaceStatusCheckRequest\x1a%.coordinator.SpaceStatusCheckResponse\x12k\n" +
@@ -3747,7 +4028,9 @@ const file_coordinator_coordinatorproto_protos_coordinator_proto_rawDesc = "" +
 	"InboxFetch\x12\x1e.coordinator.InboxFetchRequest\x1a\x1f.coordinator.InboxFetchResponse\x12\\\n" +
 	"\x0fInboxAddMessage\x12#.coordinator.InboxAddMessageRequest\x1a$.coordinator.InboxAddMessageResponse\x12[\n" +
 	"\x0fNotifySubscribe\x12#.coordinator.NotifySubscribeRequest\x1a!.coordinator.NotifySubscribeEvent0\x01\x12\\\n" +
-	"\x0fAclUploadInvite\x12#.coordinator.AclUploadInviteRequest\x1a$.coordinator.AclUploadInviteResponseB\x1eZ\x1ccoordinator/coordinatorprotob\x06proto3"
+	"\x0fAclUploadInvite\x12#.coordinator.AclUploadInviteRequest\x1a$.coordinator.AclUploadInviteResponse\x12V\n" +
+	"\rFileLimitsGet\x12!.coordinator.FileLimitsGetRequest\x1a\".coordinator.FileLimitsGetResponse\x12\\\n" +
+	"\x0fFileUsageReport\x12#.coordinator.FileUsageReportRequest\x1a$.coordinator.FileUsageReportResponseB\x1eZ\x1ccoordinator/coordinatorprotob\x06proto3"
 
 var (
 	file_coordinator_coordinatorproto_protos_coordinator_proto_rawDescOnce sync.Once
@@ -3762,7 +4045,7 @@ func file_coordinator_coordinatorproto_protos_coordinator_proto_rawDescGZIP() []
 }
 
 var file_coordinator_coordinatorproto_protos_coordinator_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_coordinator_coordinatorproto_protos_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
 var file_coordinator_coordinatorproto_protos_coordinator_proto_goTypes = []any{
 	(ErrorCodes)(0),                             // 0: coordinator.ErrorCodes
 	(SpaceStatus)(0),                            // 1: coordinator.SpaceStatus
@@ -3827,6 +4110,11 @@ var file_coordinator_coordinatorproto_protos_coordinator_proto_goTypes = []any{
 	(*NotifySubscribeEvent)(nil),                // 60: coordinator.NotifySubscribeEvent
 	(*AclUploadInviteRequest)(nil),              // 61: coordinator.AclUploadInviteRequest
 	(*AclUploadInviteResponse)(nil),             // 62: coordinator.AclUploadInviteResponse
+	(*FileLimitsGetRequest)(nil),                // 63: coordinator.FileLimitsGetRequest
+	(*FileLimitsGetResponse)(nil),               // 64: coordinator.FileLimitsGetResponse
+	(*FileUsageReportRequest)(nil),              // 65: coordinator.FileUsageReportRequest
+	(*FileUsageRow)(nil),                        // 66: coordinator.FileUsageRow
+	(*FileUsageReportResponse)(nil),             // 67: coordinator.FileUsageReportResponse
 }
 var file_coordinator_coordinatorproto_protos_coordinator_proto_depIdxs = []int32{
 	1,  // 0: coordinator.SpaceStatusPayload.status:type_name -> coordinator.SpaceStatus
@@ -3853,49 +4141,54 @@ var file_coordinator_coordinatorproto_protos_coordinator_proto_depIdxs = []int32
 	52, // 21: coordinator.InboxAddMessageRequest.message:type_name -> coordinator.InboxMessage
 	10, // 22: coordinator.NotifySubscribeRequest.eventType:type_name -> coordinator.NotifyEventType
 	10, // 23: coordinator.NotifySubscribeEvent.eventType:type_name -> coordinator.NotifyEventType
-	11, // 24: coordinator.Coordinator.SpaceSign:input_type -> coordinator.SpaceSignRequest
-	17, // 25: coordinator.Coordinator.SpaceStatusCheck:input_type -> coordinator.SpaceStatusCheckRequest
-	19, // 26: coordinator.Coordinator.SpaceStatusCheckMany:input_type -> coordinator.SpaceStatusCheckManyRequest
-	22, // 27: coordinator.Coordinator.SpaceStatusChange:input_type -> coordinator.SpaceStatusChangeRequest
-	24, // 28: coordinator.Coordinator.SpaceMakeShareable:input_type -> coordinator.SpaceMakeShareableRequest
-	26, // 29: coordinator.Coordinator.SpaceMakeUnshareable:input_type -> coordinator.SpaceMakeUnshareableRequest
-	28, // 30: coordinator.Coordinator.NetworkConfiguration:input_type -> coordinator.NetworkConfigurationRequest
-	33, // 31: coordinator.Coordinator.DeletionLog:input_type -> coordinator.DeletionLogRequest
-	36, // 32: coordinator.Coordinator.SpaceDelete:input_type -> coordinator.SpaceDeleteRequest
-	38, // 33: coordinator.Coordinator.AccountDelete:input_type -> coordinator.AccountDeleteRequest
-	41, // 34: coordinator.Coordinator.AccountRevertDeletion:input_type -> coordinator.AccountRevertDeletionRequest
-	43, // 35: coordinator.Coordinator.AclAddRecord:input_type -> coordinator.AclAddRecordRequest
-	45, // 36: coordinator.Coordinator.AclGetRecords:input_type -> coordinator.AclGetRecordsRequest
-	47, // 37: coordinator.Coordinator.AccountLimitsSet:input_type -> coordinator.AccountLimitsSetRequest
-	49, // 38: coordinator.Coordinator.AclEventLog:input_type -> coordinator.AclEventLogRequest
-	55, // 39: coordinator.Coordinator.InboxFetch:input_type -> coordinator.InboxFetchRequest
-	57, // 40: coordinator.Coordinator.InboxAddMessage:input_type -> coordinator.InboxAddMessageRequest
-	59, // 41: coordinator.Coordinator.NotifySubscribe:input_type -> coordinator.NotifySubscribeRequest
-	61, // 42: coordinator.Coordinator.AclUploadInvite:input_type -> coordinator.AclUploadInviteRequest
-	14, // 43: coordinator.Coordinator.SpaceSign:output_type -> coordinator.SpaceSignResponse
-	18, // 44: coordinator.Coordinator.SpaceStatusCheck:output_type -> coordinator.SpaceStatusCheckResponse
-	20, // 45: coordinator.Coordinator.SpaceStatusCheckMany:output_type -> coordinator.SpaceStatusCheckManyResponse
-	23, // 46: coordinator.Coordinator.SpaceStatusChange:output_type -> coordinator.SpaceStatusChangeResponse
-	25, // 47: coordinator.Coordinator.SpaceMakeShareable:output_type -> coordinator.SpaceMakeShareableResponse
-	27, // 48: coordinator.Coordinator.SpaceMakeUnshareable:output_type -> coordinator.SpaceMakeUnshareableResponse
-	29, // 49: coordinator.Coordinator.NetworkConfiguration:output_type -> coordinator.NetworkConfigurationResponse
-	34, // 50: coordinator.Coordinator.DeletionLog:output_type -> coordinator.DeletionLogResponse
-	37, // 51: coordinator.Coordinator.SpaceDelete:output_type -> coordinator.SpaceDeleteResponse
-	40, // 52: coordinator.Coordinator.AccountDelete:output_type -> coordinator.AccountDeleteResponse
-	42, // 53: coordinator.Coordinator.AccountRevertDeletion:output_type -> coordinator.AccountRevertDeletionResponse
-	44, // 54: coordinator.Coordinator.AclAddRecord:output_type -> coordinator.AclAddRecordResponse
-	46, // 55: coordinator.Coordinator.AclGetRecords:output_type -> coordinator.AclGetRecordsResponse
-	48, // 56: coordinator.Coordinator.AccountLimitsSet:output_type -> coordinator.AccountLimitsSetResponse
-	50, // 57: coordinator.Coordinator.AclEventLog:output_type -> coordinator.AclEventLogResponse
-	56, // 58: coordinator.Coordinator.InboxFetch:output_type -> coordinator.InboxFetchResponse
-	58, // 59: coordinator.Coordinator.InboxAddMessage:output_type -> coordinator.InboxAddMessageResponse
-	60, // 60: coordinator.Coordinator.NotifySubscribe:output_type -> coordinator.NotifySubscribeEvent
-	62, // 61: coordinator.Coordinator.AclUploadInvite:output_type -> coordinator.AclUploadInviteResponse
-	43, // [43:62] is the sub-list for method output_type
-	24, // [24:43] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	66, // 24: coordinator.FileUsageReportRequest.rows:type_name -> coordinator.FileUsageRow
+	11, // 25: coordinator.Coordinator.SpaceSign:input_type -> coordinator.SpaceSignRequest
+	17, // 26: coordinator.Coordinator.SpaceStatusCheck:input_type -> coordinator.SpaceStatusCheckRequest
+	19, // 27: coordinator.Coordinator.SpaceStatusCheckMany:input_type -> coordinator.SpaceStatusCheckManyRequest
+	22, // 28: coordinator.Coordinator.SpaceStatusChange:input_type -> coordinator.SpaceStatusChangeRequest
+	24, // 29: coordinator.Coordinator.SpaceMakeShareable:input_type -> coordinator.SpaceMakeShareableRequest
+	26, // 30: coordinator.Coordinator.SpaceMakeUnshareable:input_type -> coordinator.SpaceMakeUnshareableRequest
+	28, // 31: coordinator.Coordinator.NetworkConfiguration:input_type -> coordinator.NetworkConfigurationRequest
+	33, // 32: coordinator.Coordinator.DeletionLog:input_type -> coordinator.DeletionLogRequest
+	36, // 33: coordinator.Coordinator.SpaceDelete:input_type -> coordinator.SpaceDeleteRequest
+	38, // 34: coordinator.Coordinator.AccountDelete:input_type -> coordinator.AccountDeleteRequest
+	41, // 35: coordinator.Coordinator.AccountRevertDeletion:input_type -> coordinator.AccountRevertDeletionRequest
+	43, // 36: coordinator.Coordinator.AclAddRecord:input_type -> coordinator.AclAddRecordRequest
+	45, // 37: coordinator.Coordinator.AclGetRecords:input_type -> coordinator.AclGetRecordsRequest
+	47, // 38: coordinator.Coordinator.AccountLimitsSet:input_type -> coordinator.AccountLimitsSetRequest
+	49, // 39: coordinator.Coordinator.AclEventLog:input_type -> coordinator.AclEventLogRequest
+	55, // 40: coordinator.Coordinator.InboxFetch:input_type -> coordinator.InboxFetchRequest
+	57, // 41: coordinator.Coordinator.InboxAddMessage:input_type -> coordinator.InboxAddMessageRequest
+	59, // 42: coordinator.Coordinator.NotifySubscribe:input_type -> coordinator.NotifySubscribeRequest
+	61, // 43: coordinator.Coordinator.AclUploadInvite:input_type -> coordinator.AclUploadInviteRequest
+	63, // 44: coordinator.Coordinator.FileLimitsGet:input_type -> coordinator.FileLimitsGetRequest
+	65, // 45: coordinator.Coordinator.FileUsageReport:input_type -> coordinator.FileUsageReportRequest
+	14, // 46: coordinator.Coordinator.SpaceSign:output_type -> coordinator.SpaceSignResponse
+	18, // 47: coordinator.Coordinator.SpaceStatusCheck:output_type -> coordinator.SpaceStatusCheckResponse
+	20, // 48: coordinator.Coordinator.SpaceStatusCheckMany:output_type -> coordinator.SpaceStatusCheckManyResponse
+	23, // 49: coordinator.Coordinator.SpaceStatusChange:output_type -> coordinator.SpaceStatusChangeResponse
+	25, // 50: coordinator.Coordinator.SpaceMakeShareable:output_type -> coordinator.SpaceMakeShareableResponse
+	27, // 51: coordinator.Coordinator.SpaceMakeUnshareable:output_type -> coordinator.SpaceMakeUnshareableResponse
+	29, // 52: coordinator.Coordinator.NetworkConfiguration:output_type -> coordinator.NetworkConfigurationResponse
+	34, // 53: coordinator.Coordinator.DeletionLog:output_type -> coordinator.DeletionLogResponse
+	37, // 54: coordinator.Coordinator.SpaceDelete:output_type -> coordinator.SpaceDeleteResponse
+	40, // 55: coordinator.Coordinator.AccountDelete:output_type -> coordinator.AccountDeleteResponse
+	42, // 56: coordinator.Coordinator.AccountRevertDeletion:output_type -> coordinator.AccountRevertDeletionResponse
+	44, // 57: coordinator.Coordinator.AclAddRecord:output_type -> coordinator.AclAddRecordResponse
+	46, // 58: coordinator.Coordinator.AclGetRecords:output_type -> coordinator.AclGetRecordsResponse
+	48, // 59: coordinator.Coordinator.AccountLimitsSet:output_type -> coordinator.AccountLimitsSetResponse
+	50, // 60: coordinator.Coordinator.AclEventLog:output_type -> coordinator.AclEventLogResponse
+	56, // 61: coordinator.Coordinator.InboxFetch:output_type -> coordinator.InboxFetchResponse
+	58, // 62: coordinator.Coordinator.InboxAddMessage:output_type -> coordinator.InboxAddMessageResponse
+	60, // 63: coordinator.Coordinator.NotifySubscribe:output_type -> coordinator.NotifySubscribeEvent
+	62, // 64: coordinator.Coordinator.AclUploadInvite:output_type -> coordinator.AclUploadInviteResponse
+	64, // 65: coordinator.Coordinator.FileLimitsGet:output_type -> coordinator.FileLimitsGetResponse
+	67, // 66: coordinator.Coordinator.FileUsageReport:output_type -> coordinator.FileUsageReportResponse
+	46, // [46:67] is the sub-list for method output_type
+	25, // [25:46] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_coordinator_coordinatorproto_protos_coordinator_proto_init() }
@@ -3909,7 +4202,7 @@ func file_coordinator_coordinatorproto_protos_coordinator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_coordinator_coordinatorproto_protos_coordinator_proto_rawDesc), len(file_coordinator_coordinatorproto_protos_coordinator_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   52,
+			NumMessages:   57,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/coordinator/coordinatorproto/coordinator_drpc.pb.go
+++ b/coordinator/coordinatorproto/coordinator_drpc.pb.go
@@ -52,6 +52,8 @@ type DRPCCoordinatorClient interface {
 	InboxAddMessage(ctx context.Context, in *InboxAddMessageRequest) (*InboxAddMessageResponse, error)
 	NotifySubscribe(ctx context.Context, in *NotifySubscribeRequest) (DRPCCoordinator_NotifySubscribeClient, error)
 	AclUploadInvite(ctx context.Context, in *AclUploadInviteRequest) (*AclUploadInviteResponse, error)
+	FileLimitsGet(ctx context.Context, in *FileLimitsGetRequest) (*FileLimitsGetResponse, error)
+	FileUsageReport(ctx context.Context, in *FileUsageReportRequest) (*FileUsageReportResponse, error)
 }
 
 type drpcCoordinatorClient struct {
@@ -266,6 +268,24 @@ func (c *drpcCoordinatorClient) AclUploadInvite(ctx context.Context, in *AclUplo
 	return out, nil
 }
 
+func (c *drpcCoordinatorClient) FileLimitsGet(ctx context.Context, in *FileLimitsGetRequest) (*FileLimitsGetResponse, error) {
+	out := new(FileLimitsGetResponse)
+	err := c.cc.Invoke(ctx, "/coordinator.Coordinator/FileLimitsGet", drpcEncoding_File_coordinator_coordinatorproto_protos_coordinator_proto{}, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *drpcCoordinatorClient) FileUsageReport(ctx context.Context, in *FileUsageReportRequest) (*FileUsageReportResponse, error) {
+	out := new(FileUsageReportResponse)
+	err := c.cc.Invoke(ctx, "/coordinator.Coordinator/FileUsageReport", drpcEncoding_File_coordinator_coordinatorproto_protos_coordinator_proto{}, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 type DRPCCoordinatorServer interface {
 	SpaceSign(context.Context, *SpaceSignRequest) (*SpaceSignResponse, error)
 	SpaceStatusCheck(context.Context, *SpaceStatusCheckRequest) (*SpaceStatusCheckResponse, error)
@@ -286,6 +306,8 @@ type DRPCCoordinatorServer interface {
 	InboxAddMessage(context.Context, *InboxAddMessageRequest) (*InboxAddMessageResponse, error)
 	NotifySubscribe(*NotifySubscribeRequest, DRPCCoordinator_NotifySubscribeStream) error
 	AclUploadInvite(context.Context, *AclUploadInviteRequest) (*AclUploadInviteResponse, error)
+	FileLimitsGet(context.Context, *FileLimitsGetRequest) (*FileLimitsGetResponse, error)
+	FileUsageReport(context.Context, *FileUsageReportRequest) (*FileUsageReportResponse, error)
 }
 
 type DRPCCoordinatorUnimplementedServer struct{}
@@ -366,9 +388,17 @@ func (s *DRPCCoordinatorUnimplementedServer) AclUploadInvite(context.Context, *A
 	return nil, drpcerr.WithCode(errors.New("Unimplemented"), drpcerr.Unimplemented)
 }
 
+func (s *DRPCCoordinatorUnimplementedServer) FileLimitsGet(context.Context, *FileLimitsGetRequest) (*FileLimitsGetResponse, error) {
+	return nil, drpcerr.WithCode(errors.New("Unimplemented"), drpcerr.Unimplemented)
+}
+
+func (s *DRPCCoordinatorUnimplementedServer) FileUsageReport(context.Context, *FileUsageReportRequest) (*FileUsageReportResponse, error) {
+	return nil, drpcerr.WithCode(errors.New("Unimplemented"), drpcerr.Unimplemented)
+}
+
 type DRPCCoordinatorDescription struct{}
 
-func (DRPCCoordinatorDescription) NumMethods() int { return 19 }
+func (DRPCCoordinatorDescription) NumMethods() int { return 21 }
 
 func (DRPCCoordinatorDescription) Method(n int) (string, drpc.Encoding, drpc.Receiver, interface{}, bool) {
 	switch n {
@@ -543,6 +573,24 @@ func (DRPCCoordinatorDescription) Method(n int) (string, drpc.Encoding, drpc.Rec
 						in1.(*AclUploadInviteRequest),
 					)
 			}, DRPCCoordinatorServer.AclUploadInvite, true
+	case 19:
+		return "/coordinator.Coordinator/FileLimitsGet", drpcEncoding_File_coordinator_coordinatorproto_protos_coordinator_proto{},
+			func(srv interface{}, ctx context.Context, in1, in2 interface{}) (drpc.Message, error) {
+				return srv.(DRPCCoordinatorServer).
+					FileLimitsGet(
+						ctx,
+						in1.(*FileLimitsGetRequest),
+					)
+			}, DRPCCoordinatorServer.FileLimitsGet, true
+	case 20:
+		return "/coordinator.Coordinator/FileUsageReport", drpcEncoding_File_coordinator_coordinatorproto_protos_coordinator_proto{},
+			func(srv interface{}, ctx context.Context, in1, in2 interface{}) (drpc.Message, error) {
+				return srv.(DRPCCoordinatorServer).
+					FileUsageReport(
+						ctx,
+						in1.(*FileUsageReportRequest),
+					)
+			}, DRPCCoordinatorServer.FileUsageReport, true
 	default:
 		return "", nil, nil, nil, false
 	}
@@ -847,6 +895,38 @@ type drpcCoordinator_AclUploadInviteStream struct {
 }
 
 func (x *drpcCoordinator_AclUploadInviteStream) SendAndClose(m *AclUploadInviteResponse) error {
+	if err := x.MsgSend(m, drpcEncoding_File_coordinator_coordinatorproto_protos_coordinator_proto{}); err != nil {
+		return err
+	}
+	return x.CloseSend()
+}
+
+type DRPCCoordinator_FileLimitsGetStream interface {
+	drpc.Stream
+	SendAndClose(*FileLimitsGetResponse) error
+}
+
+type drpcCoordinator_FileLimitsGetStream struct {
+	drpc.Stream
+}
+
+func (x *drpcCoordinator_FileLimitsGetStream) SendAndClose(m *FileLimitsGetResponse) error {
+	if err := x.MsgSend(m, drpcEncoding_File_coordinator_coordinatorproto_protos_coordinator_proto{}); err != nil {
+		return err
+	}
+	return x.CloseSend()
+}
+
+type DRPCCoordinator_FileUsageReportStream interface {
+	drpc.Stream
+	SendAndClose(*FileUsageReportResponse) error
+}
+
+type drpcCoordinator_FileUsageReportStream struct {
+	drpc.Stream
+}
+
+func (x *drpcCoordinator_FileUsageReportStream) SendAndClose(m *FileUsageReportResponse) error {
 	if err := x.MsgSend(m, drpcEncoding_File_coordinator_coordinatorproto_protos_coordinator_proto{}); err != nil {
 		return err
 	}

--- a/coordinator/coordinatorproto/coordinator_vtproto.pb.go
+++ b/coordinator/coordinatorproto/coordinator_vtproto.pb.go
@@ -2563,6 +2563,236 @@ func (m *AclUploadInviteResponse) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
+func (m *FileLimitsGetRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FileLimitsGetRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *FileLimitsGetRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Identity) > 0 {
+		i -= len(m.Identity)
+		copy(dAtA[i:], m.Identity)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Identity)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.SpaceId) > 0 {
+		i -= len(m.SpaceId)
+		copy(dAtA[i:], m.SpaceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SpaceId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FileLimitsGetResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FileLimitsGetResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *FileLimitsGetResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.SpaceLimitBytes != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.SpaceLimitBytes))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.AccountTotalUsageBytes != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.AccountTotalUsageBytes))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.AccountLimitBytes != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.AccountLimitBytes))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FileUsageReportRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FileUsageReportRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *FileUsageReportRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Rows) > 0 {
+		for iNdEx := len(m.Rows) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Rows[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FileUsageRow) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FileUsageRow) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *FileUsageRow) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.DurableFilesCount != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DurableFilesCount))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.DurableBytes != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DurableBytes))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Identity) > 0 {
+		i -= len(m.Identity)
+		copy(dAtA[i:], m.Identity)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Identity)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.SpaceId) > 0 {
+		i -= len(m.SpaceId)
+		copy(dAtA[i:], m.SpaceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SpaceId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FileUsageReportResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FileUsageReportResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *FileUsageReportResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *SpaceSignRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -3518,6 +3748,93 @@ func (m *AclUploadInviteRequest) SizeVT() (n int) {
 }
 
 func (m *AclUploadInviteResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *FileLimitsGetRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.SpaceId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Identity)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *FileLimitsGetResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.AccountLimitBytes != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.AccountLimitBytes))
+	}
+	if m.AccountTotalUsageBytes != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.AccountTotalUsageBytes))
+	}
+	if m.SpaceLimitBytes != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.SpaceLimitBytes))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *FileUsageReportRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Rows) > 0 {
+		for _, e := range m.Rows {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *FileUsageRow) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.SpaceId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Identity)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.DurableBytes != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.DurableBytes))
+	}
+	if m.DurableFilesCount != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.DurableFilesCount))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *FileUsageReportResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -9504,6 +9821,518 @@ func (m *AclUploadInviteResponse) UnmarshalVT(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: AclUploadInviteResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *FileLimitsGetRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: FileLimitsGetRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: FileLimitsGetRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpaceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SpaceId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Identity", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Identity = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *FileLimitsGetResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: FileLimitsGetResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: FileLimitsGetResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AccountLimitBytes", wireType)
+			}
+			m.AccountLimitBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.AccountLimitBytes |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AccountTotalUsageBytes", wireType)
+			}
+			m.AccountTotalUsageBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.AccountTotalUsageBytes |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpaceLimitBytes", wireType)
+			}
+			m.SpaceLimitBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SpaceLimitBytes |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *FileUsageReportRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: FileUsageReportRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: FileUsageReportRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rows", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Rows = append(m.Rows, &FileUsageRow{})
+			if err := m.Rows[len(m.Rows)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *FileUsageRow) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: FileUsageRow: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: FileUsageRow: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpaceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SpaceId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Identity", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Identity = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DurableBytes", wireType)
+			}
+			m.DurableBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DurableBytes |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DurableFilesCount", wireType)
+			}
+			m.DurableFilesCount = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DurableFilesCount |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *FileUsageReportResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: FileUsageReportResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: FileUsageReportResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/coordinator/coordinatorproto/protos/coordinator.proto
+++ b/coordinator/coordinatorproto/protos/coordinator.proto
@@ -57,6 +57,12 @@ service Coordinator {
   rpc NotifySubscribe(NotifySubscribeRequest) returns (stream NotifySubscribeEvent);
   // AclUploadInvite uploads invite binary data to the filenodes
   rpc AclUploadInvite(AclUploadInviteRequest) returns (AclUploadInviteResponse);
+  // FileLimitsGet returns the file-storage pool bounds for an uploader identity in a space (files v2; fileV2 nodes only).
+  // The response carries absolute bounds — the caller computes effective headroom locally.
+  rpc FileLimitsGet(FileLimitsGetRequest) returns (FileLimitsGetResponse);
+  // FileUsageReport accepts per-(space, identity) durable file usage reports from fileV2 nodes.
+  // The reporting node is taken from the authenticated peer context. Values are absolute (idempotent re-reports).
+  rpc FileUsageReport(FileUsageReportRequest) returns (FileUsageReportResponse);
 }
 
 
@@ -500,3 +506,33 @@ message AclUploadInviteRequest {
 }
 
 message AclUploadInviteResponse {}
+
+message FileLimitsGetRequest {
+  string spaceId = 1;
+  // Identity is the uploader account identity whose pool bounds are requested
+  string identity = 2;
+}
+
+message FileLimitsGetResponse {
+  // AccountLimitBytes is the identity's total file-storage cap (the common account pool)
+  uint64 accountLimitBytes = 1;
+  // AccountTotalUsageBytes is the coordinator-aggregated durable usage across all the identity's spaces
+  uint64 accountTotalUsageBytes = 2;
+  // SpaceLimitBytes is an optional space-scoped cap; 0 = unset
+  uint64 spaceLimitBytes = 3;
+}
+
+message FileUsageReportRequest {
+  repeated FileUsageRow rows = 1;
+}
+
+message FileUsageRow {
+  string spaceId = 1;
+  // Identity is the charged uploader identity (the author of the root's earliest bind row)
+  string identity = 2;
+  // DurableBytes is the HEAD-measured durable usage of this (space, identity) slice; in-flight is never reported
+  uint64 durableBytes = 3;
+  uint64 durableFilesCount = 4;
+}
+
+message FileUsageReportResponse {}


### PR DESCRIPTION
## What

The coordinator API for files-v2 storage limits (SYN-19, design groomed + expert-reviewed 2026-07-04):

- `FileLimitsGet(spaceId, identity) → {accountLimitBytes, accountTotalUsageBytes, spaceLimitBytes}` — absolute account-pool bounds for an uploader identity; the broker computes effective headroom locally (`accountFree + localDurable` add-back, MIN space cap). `spaceLimitBytes` (0 = unset) reserves space-scoped caps with zero future broker change.
- `FileUsageReport(rows: [{spaceId, identity, durableBytes, durableFilesCount}])` — absolute, idempotent per-(space, identity) durable usage reports; the reporting node comes from the authenticated peer context.
- `coordinatorclient` methods + regenerated mocks.
- `fileprotov2.SpaceQuota` gains `accountLimitBytes`/`accountUsageBytes` so SpaceInfo can surface the requester's pool.

## Why

Files are charged to their uploader identity and all of an identity's spaces share one pool; filenodes are sharded (RF=2, no common index), so only the coordinator can aggregate the identity total. Absolute bounds + local computation keep the coordinator off the synchronous upload path.

Server side: anyproto/any-sync-coordinator (same branch). Broker side: any-sync-filenode2 `cheggaaa/syn-35-coordinator-limits` (SYN-35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoLHZmQFxyhxDkkwJ7Y1jX