### PR TITLE
feat(clientspaceproto): SpaceExchangeV2 — token-based LAN space discovery

### DIFF
--- a/commonspace/clientspaceproto/clientspace.pb.go
+++ b/commonspace/clientspaceproto/clientspace.pb.go
@@ -117,6 +117,115 @@ func (x *SpaceExchangeResponse) GetSpaceIds() []string {
 	return nil
 }
 
+type SpaceExchangeV2Request struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// nonce is 32 random bytes chosen by the caller; it challenges both request and response tokens
+	Nonce []byte `protobuf:"bytes,1,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	// spaceTokens holds one 32-byte request token per caller space,
+	// padded with random tokens up to a bucket size and sorted to hide the true count
+	SpaceTokens   [][]byte     `protobuf:"bytes,2,rep,name=spaceTokens,proto3" json:"spaceTokens,omitempty"`
+	LocalServer   *LocalServer `protobuf:"bytes,3,opt,name=localServer,proto3" json:"localServer,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpaceExchangeV2Request) Reset() {
+	*x = SpaceExchangeV2Request{}
+	mi := &file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpaceExchangeV2Request) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpaceExchangeV2Request) ProtoMessage() {}
+
+func (x *SpaceExchangeV2Request) ProtoReflect() protoreflect.Message {
+	mi := &file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpaceExchangeV2Request.ProtoReflect.Descriptor instead.
+func (*SpaceExchangeV2Request) Descriptor() ([]byte, []int) {
+	return file_commonspace_clientspaceproto_protos_clientspace_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *SpaceExchangeV2Request) GetNonce() []byte {
+	if x != nil {
+		return x.Nonce
+	}
+	return nil
+}
+
+func (x *SpaceExchangeV2Request) GetSpaceTokens() [][]byte {
+	if x != nil {
+		return x.SpaceTokens
+	}
+	return nil
+}
+
+func (x *SpaceExchangeV2Request) GetLocalServer() *LocalServer {
+	if x != nil {
+		return x.LocalServer
+	}
+	return nil
+}
+
+type SpaceExchangeV2Response struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// spaceTokens holds one 32-byte response token per intersecting space —
+	// the responder's proof of membership, keyed by the caller's nonce
+	SpaceTokens   [][]byte `protobuf:"bytes,1,rep,name=spaceTokens,proto3" json:"spaceTokens,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpaceExchangeV2Response) Reset() {
+	*x = SpaceExchangeV2Response{}
+	mi := &file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpaceExchangeV2Response) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpaceExchangeV2Response) ProtoMessage() {}
+
+func (x *SpaceExchangeV2Response) ProtoReflect() protoreflect.Message {
+	mi := &file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpaceExchangeV2Response.ProtoReflect.Descriptor instead.
+func (*SpaceExchangeV2Response) Descriptor() ([]byte, []int) {
+	return file_commonspace_clientspaceproto_protos_clientspace_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *SpaceExchangeV2Response) GetSpaceTokens() [][]byte {
+	if x != nil {
+		return x.SpaceTokens
+	}
+	return nil
+}
+
 type LocalServer struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Ips           []string               `protobuf:"bytes,1,rep,name=Ips,proto3" json:"Ips,omitempty"`
@@ -127,7 +236,7 @@ type LocalServer struct {
 
 func (x *LocalServer) Reset() {
 	*x = LocalServer{}
-	mi := &file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes[2]
+	mi := &file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -139,7 +248,7 @@ func (x *LocalServer) String() string {
 func (*LocalServer) ProtoMessage() {}
 
 func (x *LocalServer) ProtoReflect() protoreflect.Message {
-	mi := &file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes[2]
+	mi := &file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -152,7 +261,7 @@ func (x *LocalServer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocalServer.ProtoReflect.Descriptor instead.
 func (*LocalServer) Descriptor() ([]byte, []int) {
-	return file_commonspace_clientspaceproto_protos_clientspace_proto_rawDescGZIP(), []int{2}
+	return file_commonspace_clientspaceproto_protos_clientspace_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *LocalServer) GetIps() []string {
@@ -178,12 +287,19 @@ const file_commonspace_clientspaceproto_protos_clientspace_proto_rawDesc = "" +
 	"\bspaceIds\x18\x01 \x03(\tR\bspaceIds\x12:\n" +
 	"\vlocalServer\x18\x02 \x01(\v2\x18.clientspace.LocalServerR\vlocalServer\"3\n" +
 	"\x15SpaceExchangeResponse\x12\x1a\n" +
-	"\bspaceIds\x18\x01 \x03(\tR\bspaceIds\"3\n" +
+	"\bspaceIds\x18\x01 \x03(\tR\bspaceIds\"\x8c\x01\n" +
+	"\x16SpaceExchangeV2Request\x12\x14\n" +
+	"\x05nonce\x18\x01 \x01(\fR\x05nonce\x12 \n" +
+	"\vspaceTokens\x18\x02 \x03(\fR\vspaceTokens\x12:\n" +
+	"\vlocalServer\x18\x03 \x01(\v2\x18.clientspace.LocalServerR\vlocalServer\";\n" +
+	"\x17SpaceExchangeV2Response\x12 \n" +
+	"\vspaceTokens\x18\x01 \x03(\fR\vspaceTokens\"3\n" +
 	"\vLocalServer\x12\x10\n" +
 	"\x03Ips\x18\x01 \x03(\tR\x03Ips\x12\x12\n" +
-	"\x04port\x18\x02 \x01(\x05R\x04port2e\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port2\xc3\x01\n" +
 	"\vClientSpace\x12V\n" +
-	"\rSpaceExchange\x12!.clientspace.SpaceExchangeRequest\x1a\".clientspace.SpaceExchangeResponseB\x1eZ\x1ccommonspace/clientspaceprotob\x06proto3"
+	"\rSpaceExchange\x12!.clientspace.SpaceExchangeRequest\x1a\".clientspace.SpaceExchangeResponse\x12\\\n" +
+	"\x0fSpaceExchangeV2\x12#.clientspace.SpaceExchangeV2Request\x1a$.clientspace.SpaceExchangeV2ResponseB\x1eZ\x1ccommonspace/clientspaceprotob\x06proto3"
 
 var (
 	file_commonspace_clientspaceproto_protos_clientspace_proto_rawDescOnce sync.Once
@@ -197,21 +313,26 @@ func file_commonspace_clientspaceproto_protos_clientspace_proto_rawDescGZIP() []
 	return file_commonspace_clientspaceproto_protos_clientspace_proto_rawDescData
 }
 
-var file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_commonspace_clientspaceproto_protos_clientspace_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_commonspace_clientspaceproto_protos_clientspace_proto_goTypes = []any{
-	(*SpaceExchangeRequest)(nil),  // 0: clientspace.SpaceExchangeRequest
-	(*SpaceExchangeResponse)(nil), // 1: clientspace.SpaceExchangeResponse
-	(*LocalServer)(nil),           // 2: clientspace.LocalServer
+	(*SpaceExchangeRequest)(nil),    // 0: clientspace.SpaceExchangeRequest
+	(*SpaceExchangeResponse)(nil),   // 1: clientspace.SpaceExchangeResponse
+	(*SpaceExchangeV2Request)(nil),  // 2: clientspace.SpaceExchangeV2Request
+	(*SpaceExchangeV2Response)(nil), // 3: clientspace.SpaceExchangeV2Response
+	(*LocalServer)(nil),             // 4: clientspace.LocalServer
 }
 var file_commonspace_clientspaceproto_protos_clientspace_proto_depIdxs = []int32{
-	2, // 0: clientspace.SpaceExchangeRequest.localServer:type_name -> clientspace.LocalServer
-	0, // 1: clientspace.ClientSpace.SpaceExchange:input_type -> clientspace.SpaceExchangeRequest
-	1, // 2: clientspace.ClientSpace.SpaceExchange:output_type -> clientspace.SpaceExchangeResponse
-	2, // [2:3] is the sub-list for method output_type
-	1, // [1:2] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	4, // 0: clientspace.SpaceExchangeRequest.localServer:type_name -> clientspace.LocalServer
+	4, // 1: clientspace.SpaceExchangeV2Request.localServer:type_name -> clientspace.LocalServer
+	0, // 2: clientspace.ClientSpace.SpaceExchange:input_type -> clientspace.SpaceExchangeRequest
+	2, // 3: clientspace.ClientSpace.SpaceExchangeV2:input_type -> clientspace.SpaceExchangeV2Request
+	1, // 4: clientspace.ClientSpace.SpaceExchange:output_type -> clientspace.SpaceExchangeResponse
+	3, // 5: clientspace.ClientSpace.SpaceExchangeV2:output_type -> clientspace.SpaceExchangeV2Response
+	4, // [4:6] is the sub-list for method output_type
+	2, // [2:4] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_commonspace_clientspaceproto_protos_clientspace_proto_init() }
@@ -225,7 +346,7 @@ func file_commonspace_clientspaceproto_protos_clientspace_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_commonspace_clientspaceproto_protos_clientspace_proto_rawDesc), len(file_commonspace_clientspaceproto_protos_clientspace_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/commonspace/clientspaceproto/clientspace_drpc.pb.go
+++ b/commonspace/clientspaceproto/clientspace_drpc.pb.go
@@ -34,6 +34,7 @@ type DRPCClientSpaceClient interface {
 	DRPCConn() drpc.Conn
 
 	SpaceExchange(ctx context.Context, in *SpaceExchangeRequest) (*SpaceExchangeResponse, error)
+	SpaceExchangeV2(ctx context.Context, in *SpaceExchangeV2Request) (*SpaceExchangeV2Response, error)
 }
 
 type drpcClientSpaceClient struct {
@@ -55,8 +56,18 @@ func (c *drpcClientSpaceClient) SpaceExchange(ctx context.Context, in *SpaceExch
 	return out, nil
 }
 
+func (c *drpcClientSpaceClient) SpaceExchangeV2(ctx context.Context, in *SpaceExchangeV2Request) (*SpaceExchangeV2Response, error) {
+	out := new(SpaceExchangeV2Response)
+	err := c.cc.Invoke(ctx, "/clientspace.ClientSpace/SpaceExchangeV2", drpcEncoding_File_commonspace_clientspaceproto_protos_clientspace_proto{}, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 type DRPCClientSpaceServer interface {
 	SpaceExchange(context.Context, *SpaceExchangeRequest) (*SpaceExchangeResponse, error)
+	SpaceExchangeV2(context.Context, *SpaceExchangeV2Request) (*SpaceExchangeV2Response, error)
 }
 
 type DRPCClientSpaceUnimplementedServer struct{}
@@ -65,9 +76,13 @@ func (s *DRPCClientSpaceUnimplementedServer) SpaceExchange(context.Context, *Spa
 	return nil, drpcerr.WithCode(errors.New("Unimplemented"), drpcerr.Unimplemented)
 }
 
+func (s *DRPCClientSpaceUnimplementedServer) SpaceExchangeV2(context.Context, *SpaceExchangeV2Request) (*SpaceExchangeV2Response, error) {
+	return nil, drpcerr.WithCode(errors.New("Unimplemented"), drpcerr.Unimplemented)
+}
+
 type DRPCClientSpaceDescription struct{}
 
-func (DRPCClientSpaceDescription) NumMethods() int { return 1 }
+func (DRPCClientSpaceDescription) NumMethods() int { return 2 }
 
 func (DRPCClientSpaceDescription) Method(n int) (string, drpc.Encoding, drpc.Receiver, interface{}, bool) {
 	switch n {
@@ -80,6 +95,15 @@ func (DRPCClientSpaceDescription) Method(n int) (string, drpc.Encoding, drpc.Rec
 						in1.(*SpaceExchangeRequest),
 					)
 			}, DRPCClientSpaceServer.SpaceExchange, true
+	case 1:
+		return "/clientspace.ClientSpace/SpaceExchangeV2", drpcEncoding_File_commonspace_clientspaceproto_protos_clientspace_proto{},
+			func(srv interface{}, ctx context.Context, in1, in2 interface{}) (drpc.Message, error) {
+				return srv.(DRPCClientSpaceServer).
+					SpaceExchangeV2(
+						ctx,
+						in1.(*SpaceExchangeV2Request),
+					)
+			}, DRPCClientSpaceServer.SpaceExchangeV2, true
 	default:
 		return "", nil, nil, nil, false
 	}
@@ -99,6 +123,22 @@ type drpcClientSpace_SpaceExchangeStream struct {
 }
 
 func (x *drpcClientSpace_SpaceExchangeStream) SendAndClose(m *SpaceExchangeResponse) error {
+	if err := x.MsgSend(m, drpcEncoding_File_commonspace_clientspaceproto_protos_clientspace_proto{}); err != nil {
+		return err
+	}
+	return x.CloseSend()
+}
+
+type DRPCClientSpace_SpaceExchangeV2Stream interface {
+	drpc.Stream
+	SendAndClose(*SpaceExchangeV2Response) error
+}
+
+type drpcClientSpace_SpaceExchangeV2Stream struct {
+	drpc.Stream
+}
+
+func (x *drpcClientSpace_SpaceExchangeV2Stream) SendAndClose(m *SpaceExchangeV2Response) error {
 	if err := x.MsgSend(m, drpcEncoding_File_commonspace_clientspaceproto_protos_clientspace_proto{}); err != nil {
 		return err
 	}

--- a/commonspace/clientspaceproto/clientspace_vtproto.pb.go
+++ b/commonspace/clientspaceproto/clientspace_vtproto.pb.go
@@ -112,6 +112,107 @@ func (m *SpaceExchangeResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	return len(dAtA) - i, nil
 }
 
+func (m *SpaceExchangeV2Request) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SpaceExchangeV2Request) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SpaceExchangeV2Request) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.LocalServer != nil {
+		size, err := m.LocalServer.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.SpaceTokens) > 0 {
+		for iNdEx := len(m.SpaceTokens) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SpaceTokens[iNdEx])
+			copy(dAtA[i:], m.SpaceTokens[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SpaceTokens[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Nonce) > 0 {
+		i -= len(m.Nonce)
+		copy(dAtA[i:], m.Nonce)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Nonce)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SpaceExchangeV2Response) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SpaceExchangeV2Response) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SpaceExchangeV2Response) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.SpaceTokens) > 0 {
+		for iNdEx := len(m.SpaceTokens) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SpaceTokens[iNdEx])
+			copy(dAtA[i:], m.SpaceTokens[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SpaceTokens[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *LocalServer) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -188,6 +289,46 @@ func (m *SpaceExchangeResponse) SizeVT() (n int) {
 	if len(m.SpaceIds) > 0 {
 		for _, s := range m.SpaceIds {
 			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SpaceExchangeV2Request) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Nonce)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.SpaceTokens) > 0 {
+		for _, b := range m.SpaceTokens {
+			l = len(b)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.LocalServer != nil {
+		l = m.LocalServer.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SpaceExchangeV2Response) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.SpaceTokens) > 0 {
+		for _, b := range m.SpaceTokens {
+			l = len(b)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
@@ -393,6 +534,242 @@ func (m *SpaceExchangeResponse) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.SpaceIds = append(m.SpaceIds, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SpaceExchangeV2Request) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SpaceExchangeV2Request: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SpaceExchangeV2Request: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Nonce", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Nonce = append(m.Nonce[:0], dAtA[iNdEx:postIndex]...)
+			if m.Nonce == nil {
+				m.Nonce = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpaceTokens", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SpaceTokens = append(m.SpaceTokens, make([]byte, postIndex-iNdEx))
+			copy(m.SpaceTokens[len(m.SpaceTokens)-1], dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LocalServer", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LocalServer == nil {
+				m.LocalServer = &LocalServer{}
+			}
+			if err := m.LocalServer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SpaceExchangeV2Response) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SpaceExchangeV2Response: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SpaceExchangeV2Response: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpaceTokens", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SpaceTokens = append(m.SpaceTokens, make([]byte, postIndex-iNdEx))
+			copy(m.SpaceTokens[len(m.SpaceTokens)-1], dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/commonspace/clientspaceproto/exchange2.go
+++ b/commonspace/clientspaceproto/exchange2.go
@@ -1,0 +1,144 @@
+package clientspaceproto
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"io"
+	"sort"
+
+	"golang.org/x/crypto/hkdf"
+
+	"github.com/anyproto/any-sync/util/crypto"
+)
+
+// SpaceExchangeV2 token scheme.
+//
+// Peers never send space ids. Instead, for every space a peer holds it sends
+// HMAC-SHA256(discoveryKey, nonce || label || callerPeerId || responderPeerId),
+// where discoveryKey is derived from the space's first ACL read key — a stable
+// secret available to every member. A matching token therefore simultaneously
+// identifies a shared space and proves the sender's membership in it: strangers
+// on the LAN see values indistinguishable from random, cannot correlate them
+// across sessions (fresh nonce each run), and cannot claim spaces they are not
+// members of. Spaces whose ACL state is not available locally are skipped.
+//
+// The responder answers only for the intersection, keying its tokens by the
+// caller's nonce (challenge-response), so a response cannot be precomputed or
+// replayed. Both request and response tokens are bound to the ordered pair of
+// peer ids, so tokens observed on one connection are useless on another.
+
+const (
+	// NonceSizeV2 is the required size of SpaceExchangeV2Request.nonce
+	NonceSizeV2 = 32
+	// TokenSizeV2 is the size of every element of spaceTokens
+	TokenSizeV2 = sha256.Size
+	// MaxTokensV2 bounds spaceTokens in a request; handlers must reject bigger lists
+	MaxTokensV2 = 4096
+)
+
+// tokenBucketsV2 are the sizes request token lists are padded to, hiding the real space count
+var tokenBucketsV2 = []int{16, 32, 64, 128, 256}
+
+var (
+	labelRequestV2  = []byte("any-sync:space-exchange:v2:req")
+	labelResponseV2 = []byte("any-sync:space-exchange:v2:resp")
+	discoveryInfoV2 = []byte("any-sync:space-exchange:v2:discovery-key")
+)
+
+var ErrInvalidNonce = errors.New("space exchange v2: invalid nonce size")
+
+// DeriveDiscoveryKey derives the per-space LAN discovery key from the first ACL read key.
+// The first read key never rotates, so discovery keeps working for members whose local
+// ACL copy is behind; former members retain it, but downstream sync still enforces the
+// current ACL, so they can at most learn that a peer holds the space.
+func DeriveDiscoveryKey(firstReadKey crypto.SymKey, spaceId string) ([]byte, error) {
+	ikm, err := firstReadKey.Raw()
+	if err != nil {
+		return nil, err
+	}
+	key := make([]byte, 32)
+	if _, err = io.ReadFull(hkdf.New(sha256.New, ikm, []byte(spaceId), discoveryInfoV2), key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// NewNonceV2 returns a fresh random nonce for a SpaceExchangeV2Request
+func NewNonceV2() ([]byte, error) {
+	nonce := make([]byte, NonceSizeV2)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	return nonce, nil
+}
+
+// RequestTokenV2 computes the caller's token for one space
+func RequestTokenV2(discoveryKey, nonce []byte, callerPeerId, responderPeerId string) []byte {
+	return tokenV2(discoveryKey, labelRequestV2, nonce, callerPeerId, responderPeerId)
+}
+
+// ResponseTokenV2 computes the responder's proof token for one intersecting space,
+// keyed by the caller's nonce
+func ResponseTokenV2(discoveryKey, nonce []byte, callerPeerId, responderPeerId string) []byte {
+	return tokenV2(discoveryKey, labelResponseV2, nonce, callerPeerId, responderPeerId)
+}
+
+func tokenV2(discoveryKey, label, nonce []byte, callerPeerId, responderPeerId string) []byte {
+	mac := hmac.New(sha256.New, discoveryKey)
+	writeField(mac, label)
+	writeField(mac, nonce)
+	writeField(mac, []byte(callerPeerId))
+	writeField(mac, []byte(responderPeerId))
+	return mac.Sum(nil)
+}
+
+// writeField length-prefixes every field so variable-length peer ids cannot
+// produce colliding concatenations
+func writeField(w io.Writer, field []byte) {
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(field)))
+	_, _ = w.Write(lenBuf[:])
+	_, _ = w.Write(field)
+}
+
+// PadTokensV2 pads tokens with random fillers up to the next bucket size (beyond the
+// largest bucket — up to the next multiple of it) and sorts the result. Sorting is
+// required: without it the position of real tokens would reveal the true space count
+// the padding is meant to hide.
+func PadTokensV2(tokens [][]byte) ([][]byte, error) {
+	maxBucket := tokenBucketsV2[len(tokenBucketsV2)-1]
+	target := (len(tokens) + maxBucket - 1) / maxBucket * maxBucket
+	for _, bucket := range tokenBucketsV2 {
+		if len(tokens) <= bucket {
+			target = bucket
+			break
+		}
+	}
+	padded := make([][]byte, 0, target)
+	padded = append(padded, tokens...)
+	for len(padded) < target {
+		filler := make([]byte, TokenSizeV2)
+		if _, err := rand.Read(filler); err != nil {
+			return nil, err
+		}
+		padded = append(padded, filler)
+	}
+	sort.Slice(padded, func(i, j int) bool {
+		return string(padded[i]) < string(padded[j])
+	})
+	return padded, nil
+}
+
+// ContainsTokenV2 reports whether token is present in tokens, comparing in constant time
+func ContainsTokenV2(tokens [][]byte, token []byte) bool {
+	var found bool
+	for _, t := range tokens {
+		if hmac.Equal(t, token) {
+			found = true
+		}
+	}
+	return found
+}

--- a/commonspace/clientspaceproto/exchange2_bench_test.go
+++ b/commonspace/clientspaceproto/exchange2_bench_test.go
@@ -1,0 +1,135 @@
+package clientspaceproto
+
+import (
+	"testing"
+
+	"github.com/anyproto/any-sync/util/crypto"
+)
+
+// BenchmarkExchangeV2 measures a full exchange where both peers hold 1000 spaces,
+// 500 of them shared. Discovery keys are precomputed once outside the loops —
+// they are stable per space and meant to be cached; DeriveKeys measures that
+// one-time cost separately. Matching uses a hash set, the right approach at this
+// scale (ContainsTokenV2's linear scan is for small sets).
+func BenchmarkExchangeV2(b *testing.B) {
+	const (
+		spacesPerPeer = 1000
+		shared        = 500
+	)
+	caller, responder := "peerA", "peerB"
+
+	newKeys := func(n int) []crypto.SymKey {
+		keys := make([]crypto.SymKey, n)
+		for i := range keys {
+			key, err := crypto.NewRandomAES()
+			if err != nil {
+				b.Fatal(err)
+			}
+			keys[i] = key
+		}
+		return keys
+	}
+	deriveAll := func(keys []crypto.SymKey, ids []string) [][]byte {
+		dks := make([][]byte, len(keys))
+		for i := range keys {
+			dk, err := DeriveDiscoveryKey(keys[i], ids[i])
+			if err != nil {
+				b.Fatal(err)
+			}
+			dks[i] = dk
+		}
+		return dks
+	}
+
+	sharedKeys := newKeys(shared)
+	callerKeys := append(append([]crypto.SymKey{}, sharedKeys...), newKeys(spacesPerPeer-shared)...)
+	responderKeys := append(append([]crypto.SymKey{}, sharedKeys...), newKeys(spacesPerPeer-shared)...)
+	callerIds := make([]string, spacesPerPeer)
+	responderIds := make([]string, spacesPerPeer)
+	for i := range spacesPerPeer {
+		if i < shared {
+			callerIds[i] = "shared" + string(rune('0'+i%10)) + string(rune('a'+i/10%26)) + string(rune('a'+i/260))
+			responderIds[i] = callerIds[i]
+		} else {
+			callerIds[i] = "caller-only-" + string(rune('a'+i%26)) + string(rune('a'+i/26%26)) + string(rune('a'+i/676))
+			responderIds[i] = "responder-only-" + string(rune('a'+i%26)) + string(rune('a'+i/26%26)) + string(rune('a'+i/676))
+		}
+	}
+	callerDks := deriveAll(callerKeys, callerIds)
+	responderDks := deriveAll(responderKeys, responderIds)
+
+	nonce, err := NewNonceV2()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	buildRequest := func() [][]byte {
+		tokens := make([][]byte, len(callerDks))
+		for i, dk := range callerDks {
+			tokens[i] = RequestTokenV2(dk, nonce, caller, responder)
+		}
+		padded, err := PadTokensV2(tokens)
+		if err != nil {
+			b.Fatal(err)
+		}
+		return padded
+	}
+	handleRequest := func(reqTokens [][]byte) [][]byte {
+		received := make(map[string]struct{}, len(reqTokens))
+		for _, t := range reqTokens {
+			received[string(t)] = struct{}{}
+		}
+		var respTokens [][]byte
+		for _, dk := range responderDks {
+			if _, ok := received[string(RequestTokenV2(dk, nonce, caller, responder))]; ok {
+				respTokens = append(respTokens, ResponseTokenV2(dk, nonce, caller, responder))
+			}
+		}
+		return respTokens
+	}
+	verifyResponse := func(respTokens [][]byte) int {
+		received := make(map[string]struct{}, len(respTokens))
+		for _, t := range respTokens {
+			received[string(t)] = struct{}{}
+		}
+		var matched int
+		for _, dk := range callerDks {
+			if _, ok := received[string(ResponseTokenV2(dk, nonce, caller, responder))]; ok {
+				matched++
+			}
+		}
+		return matched
+	}
+
+	reqTokens := buildRequest()
+	respTokens := handleRequest(reqTokens)
+	if got := verifyResponse(respTokens); got != shared {
+		b.Fatalf("expected %d shared spaces, got %d", shared, got)
+	}
+
+	b.Run("DeriveKeys", func(b *testing.B) {
+		for b.Loop() {
+			deriveAll(callerKeys, callerIds)
+		}
+	})
+	b.Run("CallerBuildRequest", func(b *testing.B) {
+		for b.Loop() {
+			buildRequest()
+		}
+	})
+	b.Run("ResponderHandle", func(b *testing.B) {
+		for b.Loop() {
+			handleRequest(reqTokens)
+		}
+	})
+	b.Run("CallerVerifyResponse", func(b *testing.B) {
+		for b.Loop() {
+			verifyResponse(respTokens)
+		}
+	})
+	b.Run("FullRoundTrip", func(b *testing.B) {
+		for b.Loop() {
+			verifyResponse(handleRequest(buildRequest()))
+		}
+	})
+}

--- a/commonspace/clientspaceproto/exchange2_test.go
+++ b/commonspace/clientspaceproto/exchange2_test.go
@@ -1,0 +1,165 @@
+package clientspaceproto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-sync/util/crypto"
+)
+
+func TestDeriveDiscoveryKey(t *testing.T) {
+	readKey, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+
+	key1, err := DeriveDiscoveryKey(readKey, "space1")
+	require.NoError(t, err)
+	require.Len(t, key1, 32)
+
+	// deterministic for the same inputs
+	key1Again, err := DeriveDiscoveryKey(readKey, "space1")
+	require.NoError(t, err)
+	require.Equal(t, key1, key1Again)
+
+	// different per space even with the same read key
+	key2, err := DeriveDiscoveryKey(readKey, "space2")
+	require.NoError(t, err)
+	require.NotEqual(t, key1, key2)
+
+	// raw read key never appears as the discovery key
+	raw, err := readKey.Raw()
+	require.NoError(t, err)
+	require.NotEqual(t, raw, key1)
+}
+
+func TestTokensV2(t *testing.T) {
+	readKey, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+	dk, err := DeriveDiscoveryKey(readKey, "space1")
+	require.NoError(t, err)
+	nonce, err := NewNonceV2()
+	require.NoError(t, err)
+
+	req := RequestTokenV2(dk, nonce, "peerA", "peerB")
+	require.Len(t, req, TokenSizeV2)
+
+	// request and response tokens must differ (domain separation)
+	resp := ResponseTokenV2(dk, nonce, "peerA", "peerB")
+	require.NotEqual(t, req, resp)
+
+	// bound to the peer pair
+	require.NotEqual(t, req, RequestTokenV2(dk, nonce, "peerA", "peerC"))
+	require.NotEqual(t, req, RequestTokenV2(dk, nonce, "peerB", "peerA"))
+
+	// bound to the nonce
+	nonce2, err := NewNonceV2()
+	require.NoError(t, err)
+	require.NotEqual(t, req, RequestTokenV2(dk, nonce2, "peerA", "peerB"))
+
+	// length prefixing: shifting a boundary between peer ids must change the token
+	require.NotEqual(t, RequestTokenV2(dk, nonce, "peerAp", "eerB"), RequestTokenV2(dk, nonce, "peerA", "peerB"))
+}
+
+func TestPadTokensV2(t *testing.T) {
+	tokens := make([][]byte, 0, 20)
+	for range 20 {
+		tok, err := NewNonceV2()
+		require.NoError(t, err)
+		tokens = append(tokens, tok)
+	}
+
+	padded, err := PadTokensV2(tokens[:3])
+	require.NoError(t, err)
+	require.Len(t, padded, 16)
+
+	padded, err = PadTokensV2(tokens[:16])
+	require.NoError(t, err)
+	require.Len(t, padded, 16)
+
+	padded, err = PadTokensV2(tokens[:17])
+	require.NoError(t, err)
+	require.Len(t, padded, 32)
+
+	// all real tokens survive padding
+	for _, tok := range tokens[:17] {
+		require.True(t, ContainsTokenV2(padded, tok))
+	}
+
+	// sorted, so real token positions don't leak the true count
+	for i := 1; i < len(padded); i++ {
+		require.LessOrEqual(t, string(padded[i-1]), string(padded[i]))
+	}
+
+	// beyond the largest bucket: next multiple of it
+	big := make([][]byte, 300)
+	for i := range big {
+		big[i], err = NewNonceV2()
+		require.NoError(t, err)
+	}
+	padded, err = PadTokensV2(big)
+	require.NoError(t, err)
+	require.Len(t, padded, 512)
+}
+
+// TestExchangeV2RoundTrip simulates a full exchange between two peers
+func TestExchangeV2RoundTrip(t *testing.T) {
+	shared1, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+	shared2, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+	callerOnly, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+	responderOnly, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+
+	type space struct {
+		id      string
+		readKey crypto.SymKey
+	}
+	callerSpaces := []space{{"shared1", shared1}, {"shared2", shared2}, {"callerOnly", callerOnly}}
+	responderSpaces := []space{{"shared1", shared1}, {"shared2", shared2}, {"responderOnly", responderOnly}}
+	const caller, responder = "peerA", "peerB"
+
+	// caller builds the request
+	nonce, err := NewNonceV2()
+	require.NoError(t, err)
+	var reqTokens [][]byte
+	for _, sp := range callerSpaces {
+		dk, err := DeriveDiscoveryKey(sp.readKey, sp.id)
+		require.NoError(t, err)
+		reqTokens = append(reqTokens, RequestTokenV2(dk, nonce, caller, responder))
+	}
+	reqTokens, err = PadTokensV2(reqTokens)
+	require.NoError(t, err)
+
+	// responder matches against its own spaces and answers for the intersection
+	var respTokens [][]byte
+	var responderIntersection []string
+	for _, sp := range responderSpaces {
+		dk, err := DeriveDiscoveryKey(sp.readKey, sp.id)
+		require.NoError(t, err)
+		if ContainsTokenV2(reqTokens, RequestTokenV2(dk, nonce, caller, responder)) {
+			responderIntersection = append(responderIntersection, sp.id)
+			respTokens = append(respTokens, ResponseTokenV2(dk, nonce, caller, responder))
+		}
+	}
+	require.Equal(t, []string{"shared1", "shared2"}, responderIntersection)
+
+	// caller verifies the response
+	var callerIntersection []string
+	for _, sp := range callerSpaces {
+		dk, err := DeriveDiscoveryKey(sp.readKey, sp.id)
+		require.NoError(t, err)
+		if ContainsTokenV2(respTokens, ResponseTokenV2(dk, nonce, caller, responder)) {
+			callerIntersection = append(callerIntersection, sp.id)
+		}
+	}
+	require.Equal(t, []string{"shared1", "shared2"}, callerIntersection)
+
+	// a peer that knows only the space id (no read key) gets no match
+	wrongKey, err := crypto.NewRandomAES()
+	require.NoError(t, err)
+	dk, err := DeriveDiscoveryKey(wrongKey, "shared1")
+	require.NoError(t, err)
+	require.False(t, ContainsTokenV2(reqTokens, RequestTokenV2(dk, nonce, caller, responder)))
+}

--- a/commonspace/clientspaceproto/protos/clientspace.proto
+++ b/commonspace/clientspaceproto/protos/clientspace.proto
@@ -4,7 +4,15 @@ package clientspace;
 option go_package = "commonspace/clientspaceproto";
 
 service ClientSpace {
+    // SpaceExchange sends plaintext space id lists to any LAN peer.
+    // Deprecated: leaks the full space set to unauthenticated strangers; use SpaceExchangeV2.
     rpc SpaceExchange(SpaceExchangeRequest) returns (SpaceExchangeResponse);
+    // SpaceExchangeV2 lets two LAN peers learn only the intersection of their space sets.
+    // Instead of space ids, peers exchange per-space HMAC tokens keyed by a discovery key
+    // derived from the space's first ACL read key — a secret only members hold. A valid
+    // token both hides the space from non-members and proves the sender's membership.
+    // See clientspaceproto/exchange2.go for token derivation.
+    rpc SpaceExchangeV2(SpaceExchangeV2Request) returns (SpaceExchangeV2Response);
 }
 
 message SpaceExchangeRequest {
@@ -14,6 +22,21 @@ message SpaceExchangeRequest {
 
 message SpaceExchangeResponse {
     repeated string spaceIds = 1;
+}
+
+message SpaceExchangeV2Request {
+    // nonce is 32 random bytes chosen by the caller; it challenges both request and response tokens
+    bytes nonce = 1;
+    // spaceTokens holds one 32-byte request token per caller space,
+    // padded with random tokens up to a bucket size and sorted to hide the true count
+    repeated bytes spaceTokens = 2;
+    LocalServer localServer = 3;
+}
+
+message SpaceExchangeV2Response {
+    // spaceTokens holds one 32-byte response token per intersecting space —
+    // the responder's proof of membership, keyed by the caller's nonce
+    repeated bytes spaceTokens = 1;
 }
 
 message LocalServer {

--- a/net/secureservice/secureservice.go
+++ b/net/secureservice/secureservice.go
@@ -39,7 +39,7 @@ var (
 	// ProtoVersion 10 - reserved (not used, version alignment gap)
 	// ProtoVersion 11 - reserved (not used, version alignment gap)
 	// ProtoVersion 12 aligns with v0.12.X
-	// ProtoVersion 13 - files v2 (v2 filenodes, chash routing, space header fileprotoVersion), aligns with v0.13.X
+	// ProtoVersion 13 - files v2 (v2 filenodes, chash routing, space header fileprotoVersion), space exchange v2 (token-based LAN discovery), aligns with v0.13.X
 	ProtoVersion = uint32(13)
 )
 


### PR DESCRIPTION
## Problem

The current `ClientSpace.SpaceExchange` sends the **full plaintext list of space ids** to any peer discovered via mDNS, before knowing anything about it. Any device on the same LAN can:
- enumerate all spaces a device holds (metadata leak),
- track/correlate a device across networks and sessions (space ids are stable fingerprints),
- confirm a device holds a space it once learned the id of (ex-members, infra),
- push an arbitrary claimed space list and poison the local peer table.

## Approach (PSI-lite)

Peers never exchange space ids. For each space a peer sends
`HMAC-SHA256(discoveryKey, nonce ‖ label ‖ callerPeerId ‖ responderPeerId)` where
`discoveryKey = HKDF-SHA256(firstAclReadKey, salt=spaceId)`.

The first ACL read key is the base secret because it never rotates (members whose ACL copy is behind can still discover peers and then catch up) and every member holds it — unlike the space master/signing keys, which are owner-only. A matching token therefore both hides the space from non-members **and proves the sender's membership**, so peer-table poisoning is no longer possible.

- Response tokens are keyed by the **caller's** nonce (challenge-response) — no precomputation/replay.
- Tokens are bound to the ordered peer-id pair — useless on any other connection.
- Request lists are padded with random fillers to buckets (16/32/64/128/256, then multiples of 256) and **sorted**, hiding the true space count.
- Spaces without usable local ACL state are skipped — no spaceId-based fallback, which would silently break the membership-proof property.

Accepted trade-off: former members retain the first read key and can probe whether a peer still holds a space; downstream sync still enforces the current ACL. Unavoidable for offline-first discovery.

## Rollout

Gated by ProtoVersion ≥ 13. The v1 fallback must be **version-gated, never error-triggered**, otherwise an active attacker can force a downgrade to the plaintext exchange. Client-side implementation (anytype-heart `PeerDiscovered` / `rpcHandler`) is a follow-up.

## Perf

Bench with 1000 spaces per peer, 500 shared (`BenchmarkExchangeV2`): full round trip ~1.5 ms CPU across both peers + 0.66 ms one-time discovery-key derivation; ~33 KB on the wire for the padded request.

Design reviewed via external expert consult (2 rounds); ECDH-style PSI rejected as unnecessary since elements are keyed by member-only secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)