### PR TITLE
acl: only owner can create invites

### DIFF
--- a/commonspace/object/acl/list/acltestsuite_test.go
+++ b/commonspace/object/acl/list/acltestsuite_test.go
@@ -87,8 +87,9 @@ func TestAclExecutor(t *testing.T) {
 		{"a.add::y,adm,m2", nil},
 		// y (admin) can change permission of a non-admin
 		{"y.changes::x,rw", nil},
-		// e can generate another invite
-		{"e.invite::inv1Id", nil},
+		// e (admin) can no longer generate an invite, only the owner can
+		{"e.invite::inv1Id", ErrInsufficientPermissions},
+		{"a.invite::inv1Id", nil},
 		// b tries to join again
 		{"b.join::inv1Id", nil},
 		// e approves b
@@ -118,8 +119,11 @@ func TestAclExecutor(t *testing.T) {
 		{"a.batch::remove:e,y;add:z,rw,mz|u,r,mu;revoke:inv1Id;approve:l,r;approve:p,adm;decline:s", nil},
 		{"p.remove::l", nil},
 		{"s.join::inv1Id", ErrNoSuchInvite},
-		{"p.invite::i1", nil},
-		{"p.invite::i2", nil},
+		// p (admin) can no longer generate invites either
+		{"p.invite::i1", ErrInsufficientPermissions},
+		{"a.invite::i1", nil},
+		{"p.invite::i2", ErrInsufficientPermissions},
+		{"a.invite::i2", nil},
 		{"r.join::i1", nil},
 		{"q.join::i2", nil},
 		{"p.batch::revoke:i1;revoke:i2", nil},

--- a/commonspace/object/acl/list/list_test.go
+++ b/commonspace/object/acl/list/list_test.go
@@ -920,6 +920,31 @@ func TestAclList_AdminCannotApproveAsAdmin(t *testing.T) {
 	}
 }
 
+// FR3: only the owner can create an invite, regardless of the permission level it grants.
+func TestAclList_AdminCannotCreateInvite(t *testing.T) {
+	a := NewAclExecutor("spaceId")
+	cmds := []struct {
+		cmd string
+		err error
+	}{
+		{"a.init::a", nil},
+		{"a.invite::invId", nil},
+		{"e.join::invId", nil},
+		{"a.approve::e,adm", nil},
+		// e (admin) cannot create a request-to-join invite
+		{"e.invite::eReqInv", ErrInsufficientPermissions},
+		// e (admin) cannot create an anyone-can-join invite, even at Reader or Writer level
+		{"e.invite_anyone::eAnyInvReader,r", ErrInsufficientPermissions},
+		{"e.invite_anyone::eAnyInvWriter,rw", ErrInsufficientPermissions},
+		// owner can still create invites of any kind
+		{"a.invite::aReqInv", nil},
+		{"a.invite_anyone::aAnyInv,rw", nil},
+	}
+	for _, c := range cmds {
+		require.Equal(t, c.err, a.Execute(c.cmd), c.cmd)
+	}
+}
+
 // FR2: only the owner can remove an Admin (revoking via account removal).
 func TestAclList_AdminCannotRemoveAdmin(t *testing.T) {
 	a := NewAclExecutor("spaceId")

--- a/commonspace/object/acl/list/validator.go
+++ b/commonspace/object/acl/list/validator.go
@@ -268,17 +268,13 @@ func (c *contentValidator) ValidateInvite(ch *aclrecordproto.AclAccountInvite, a
 	if !c.verifier.ShouldValidate() {
 		return nil
 	}
-	authorPerms := c.aclState.Permissions(authorIdentity)
-	if !authorPerms.CanManageAccounts() {
+	if !c.aclState.Permissions(authorIdentity).IsOwner() {
+		// only the owner can create an invite (FR3)
 		return ErrInsufficientPermissions
 	}
 	permissions := AclPermissions(ch.Permissions)
 	if ch.InviteType == aclrecordproto.AclInviteType_AnyoneCanJoin {
 		if permissions.IsOwner() || permissions.NoPermissions() || permissions.IsGuest() {
-			return ErrInsufficientPermissions
-		}
-		if permissions.IsAdmin() && !authorPerms.IsOwner() {
-			// only the owner can issue an Admin-granting invite (FR1)
 			return ErrInsufficientPermissions
 		}
 		if ch.EncryptedReadKey == nil {


### PR DESCRIPTION
Admins could still create invite links at the protocol level (`ValidateInvite` only checked `CanManageAccounts()`, true for Admin and Owner). Clients never expose this, and prod has no ACL record of an admin creating an invite. Now gated on `IsOwner()`.

GO-7367

## Test plan
- [x] Added `TestAclList_AdminCannotCreateInvite`
- [x] Updated `TestAclExecutor` scenario where an admin previously created invites
- [x] `go test ./...` passes