### PR TITLE
Fix race-detector failures: nodeconf observer test and webtransport shutdown

### DIFF
--- a/net/transport/webtransport/webtransport_native.go
+++ b/net/transport/webtransport/webtransport_native.go
@@ -5,10 +5,12 @@ package webtransport
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/quic-go/quic-go"
@@ -36,8 +38,10 @@ type wtTransport struct {
 	accepter    transport.Accepter
 	conf        Config
 
-	server   *wt.Server
-	udpConns []net.PacketConn
+	server    *wt.Server
+	udpConns  []net.PacketConn
+	listeners []*quic.EarlyListener
+	serveWg   sync.WaitGroup
 
 	listCtx       context.Context
 	listCtxCancel context.CancelFunc
@@ -126,17 +130,43 @@ func (t *wtTransport) Run(ctx context.Context) (err error) {
 		}
 		t.udpConns = append(t.udpConns, udpConn)
 
+		// listen and accept ourselves instead of wt.Server.Serve: Serve registers itself
+		// in the server's internal WaitGroup from this goroutine, which races with
+		// Close when the transport is shut down before the goroutine is scheduled
+		ln, err := quic.ListenEarly(udpConn, tlsConf, quicConf)
+		if err != nil {
+			return fmt.Errorf("listen quic %q: %w", addr, err)
+		}
+		t.listeners = append(t.listeners, ln)
+
 		log.Info("webtransport listener started",
 			zap.String("addr", udpConn.LocalAddr().String()),
 			zap.String("path", t.conf.Path),
 		)
+		t.serveWg.Add(1)
 		go func() {
-			if err := t.server.Serve(udpConn); err != nil {
-				log.Debug("webtransport server stopped", zap.Error(err))
-			}
+			defer t.serveWg.Done()
+			t.serveListener(ln)
 		}()
 	}
 	return nil
+}
+
+func (t *wtTransport) serveListener(ln *quic.EarlyListener) {
+	for {
+		qconn, err := ln.Accept(t.listCtx)
+		if err != nil {
+			log.Debug("webtransport server stopped", zap.Error(err))
+			return
+		}
+		t.serveWg.Add(1)
+		go func() {
+			defer t.serveWg.Done()
+			if err := t.server.ServeQUICConn(qconn); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Debug("webtransport connection closed", zap.Error(err))
+			}
+		}()
+	}
 }
 
 func (t *wtTransport) handleUpgrade(w http.ResponseWriter, r *http.Request) {
@@ -255,7 +285,13 @@ func (t *wtTransport) Close(ctx context.Context) error {
 		t.listCtxCancel()
 	}
 	if t.server != nil {
+		// closes established sessions gracefully while the udp sockets are still open
+		// and cancels the server context, unblocking ServeQUICConn calls
 		_ = t.server.Close()
+	}
+	t.serveWg.Wait()
+	for _, ln := range t.listeners {
+		_ = ln.Close()
 	}
 	for _, c := range t.udpConns {
 		_ = c.Close()

--- a/nodeconf/service_test.go
+++ b/nodeconf/service_test.go
@@ -316,7 +316,11 @@ func TestService_ObserveChanges(t *testing.T) {
 	})
 
 	fx.run(t)
-	time.Sleep(time.Millisecond * 10)
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls > 0
+	}, time.Second*5, time.Millisecond*5)
 
 	mu.Lock()
 	defer mu.Unlock()


### PR DESCRIPTION
## Summary

Fixes two failures seen when running the test suite with `-race`.

### nodeconf: flaky `TestService_ObserveChanges`

`periodicsync.Run()` fires the first configuration update in a goroutine; under the race detector it often wasn't scheduled within the test's `time.Sleep(10ms)`, so the observer hadn't fired yet. Replaced the sleep with `require.Eventually` polling for the first observer call.

### webtransport: data race on shutdown (real ordering bug)

The race reports pointed at `wtTransport.Close`, but the underlying conflict is inside `webtransport-go`: `wt.Server.Serve` does `refCount.Add(1)` in the serve goroutine spawned by `Run`, with no happens-before relative to `Close`'s `refCount.Wait()` — the documented `sync.WaitGroup` Add-vs-Wait misuse (Wait's first-waiter write races Add's 0→1 read). Besides the report, it means `Close` could return while a listener goroutine was still starting.

Fix: own the accept loop instead of calling `Serve` — `quic.ListenEarly` per listen address, accept connections in a goroutine tracked by our own `serveWg`, and serve each connection via `t.server.ServeQUICConn`, which never touches the library's `refCount` (so its `Wait` is always a no-op). Our `serveWg` is race-free because `Add`s happen either in `Run` (ordered before `Close` by the component lifecycle) or while the accept loop already holds a count. `Close` now cancels the accept context, closes the server (still closing established sessions gracefully while the UDP sockets are open), waits for all goroutines, then closes listeners and sockets.

## Testing

- `go test -race -count=10 ./nodeconf/` — clean (previously failed every run)
- `go test -race -count=12 ./net/transport/webtransport/` — clean (previously reported races roughly every other run)
- `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)