### PR TITLE
ocache: retry a load that was killed by another caller's context

### DIFF
--- a/app/ocache/entry.go
+++ b/app/ocache/entry.go
@@ -23,10 +23,16 @@ type entry struct {
 	lastUsage time.Time
 	load      chan struct{}
 	loadErr   error
-	value     Object
-	close     chan struct{}
-	mx        sync.Mutex
-	cancel    context.CancelFunc
+	// loadAborted marks a failed load whose OWN context was already done
+	// when the loadFunc returned — the load was killed (its first caller
+	// went away, or the cache is closing), not refused by the loadFunc.
+	// Written by oCache.load before the load channel closes; read only
+	// after <-load, like loadErr.
+	loadAborted bool
+	value       Object
+	close       chan struct{}
+	mx          sync.Mutex
+	cancel      context.CancelFunc
 }
 
 func newEntry(id string, value Object, state entryState) *entry {

--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -121,38 +121,68 @@ type oCache struct {
 	metrics  *metrics
 }
 
+// maxLoadRetries bounds Get's re-attempts after an aborted load (see the
+// retry in Get). Each retry is a fresh load — the failed entry is deleted
+// — so the bound only matters under a storm of loads that keep getting
+// killed mid-flight.
+const maxLoadRetries = 3
+
 func (c *oCache) Get(ctx context.Context, id string) (value Object, err error) {
 	var (
-		e    *entry
-		ok   bool
-		load bool
+		counted bool
+		retries int
 	)
-Load:
-	c.mu.Lock()
-	if c.closed {
+	for {
+		c.mu.Lock()
+		if c.closed {
+			c.mu.Unlock()
+			return nil, ErrClosed
+		}
+		e, ok := c.data[id]
+		load := false
+		if !ok {
+			e = newEntry(id, nil, entryStateLoading)
+			load = true
+			c.data[id] = e
+		}
+		e.lastUsage = time.Now()
 		c.mu.Unlock()
-		return nil, ErrClosed
+		reload, err := e.waitClose(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if reload {
+			continue
+		}
+		if !counted {
+			c.metricsGet(!load)
+			counted = true
+		}
+		if load {
+			c.load(ctx, id, e)
+			value, err = e.value, e.loadErr
+		} else {
+			value, err = e.waitLoad(ctx, id)
+		}
+		// A load runs under the context of whichever caller arrived first
+		// and its result is shared with every concurrent waiter. If that
+		// first caller goes away mid-load (its request finished, its
+		// per-round timeout fired), the load is killed with an error that
+		// has nothing to do with the waiters — retry instead of surfacing
+		// it: the failed entry is already deleted, so the retry starts a
+		// fresh load owned by a live context. loadAborted distinguishes a
+		// killed load from a loadFunc that failed on its own (an internal
+		// dial timeout returns context.DeadlineExceeded with the load's ctx
+		// still alive — that is a verdict, not an abort, and is never
+		// retried). The ctx.Err() check both scopes the retry to callers
+		// that are still alive and proves waitLoad returned via the load
+		// channel, making the loadAborted read safe.
+		if err != nil && ctx.Err() == nil && e.loadAborted && retries < maxLoadRetries {
+			retries++
+			continue
+		}
+		return value, err
 	}
-	if e, ok = c.data[id]; !ok {
-		e = newEntry(id, nil, entryStateLoading)
-		load = true
-		c.data[id] = e
-	}
-	e.lastUsage = time.Now()
-	c.mu.Unlock()
-	reload, err := e.waitClose(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	if reload {
-		goto Load
-	}
-	c.metricsGet(!load)
-	if load {
-		c.load(ctx, id, e)
-		return e.value, e.loadErr
-	}
-	return e.waitLoad(ctx, id)
 }
 
 func (c *oCache) Pick(ctx context.Context, id string) (value Object, err error) {
@@ -172,6 +202,10 @@ func (c *oCache) load(ctx context.Context, id string, e *entry) {
 	ctx, cancel := context.WithCancel(ctx)
 	e.setCancel(cancel)
 	value, err := c.loadFunc(ctx, id)
+	// Read before cancel(): a done ctx here means the load was killed
+	// (first caller gone, or cancelLoad on cache close) rather than the
+	// loadFunc failing on its own — recorded so Get's waiters can retry.
+	aborted := ctx.Err() != nil
 	cancel()
 
 	c.mu.Lock()
@@ -181,6 +215,7 @@ func (c *oCache) load(ctx context.Context, id string, e *entry) {
 	}
 	if err != nil {
 		e.loadErr = err
+		e.loadAborted = aborted
 		delete(c.data, id)
 	} else {
 		e.value = value

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -152,6 +152,102 @@ func TestOCache_Get(t *testing.T) {
 	})
 }
 
+func TestOCache_GetForeignCtxRetry(t *testing.T) {
+	t.Run("waiter survives first caller's cancellation", func(t *testing.T) {
+		// The first caller owns the load's context; every concurrent Get
+		// shares the load's result. Pre-fix, cancelling the first caller
+		// failed the waiter with a context error it did not cause.
+		var (
+			started = make(chan struct{}, 2)
+			release = make(chan struct{})
+			calls   atomic.Int32
+		)
+		c := New(func(ctx context.Context, id string) (Object, error) {
+			calls.Add(1)
+			started <- struct{}{}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-release:
+				return &testObject{name: id}, nil
+			}
+		})
+		ownerCtx, cancelOwner := context.WithCancel(context.Background())
+		ownerErr := make(chan error, 1)
+		go func() {
+			_, err := c.Get(ownerCtx, "id")
+			ownerErr <- err
+		}()
+		<-started // the owner's load is in flight
+		waiterErr := make(chan error, 1)
+		go func() {
+			val, err := c.Get(context.Background(), "id")
+			if err == nil && val == nil {
+				err = errors.New("nil value")
+			}
+			waiterErr <- err
+		}()
+		time.Sleep(time.Millisecond * 10) // let the waiter join the in-flight load
+		cancelOwner()
+		require.Equal(t, context.Canceled, <-ownerErr, "the owner's own cancellation is its error")
+		<-started // the waiter retried: a fresh load, owned by its live ctx
+		close(release)
+		require.NoError(t, <-waiterErr, "a live waiter must not inherit the owner's cancellation")
+		assert.Equal(t, int32(2), calls.Load())
+		assert.NoError(t, c.Close())
+	})
+	t.Run("no retry when the loadFunc fails with its own internal timeout", func(t *testing.T) {
+		// A loadFunc-internal deadline (e.g. a transport dial timeout)
+		// returns a context error while the load's own ctx is alive —
+		// that is a verdict about the resource, not a killed load, and
+		// must surface immediately instead of multiplying dial attempts.
+		var calls atomic.Int32
+		c := New(func(ctx context.Context, id string) (Object, error) {
+			calls.Add(1)
+			return nil, fmt.Errorf("dial: %w", context.DeadlineExceeded)
+		})
+		_, err := c.Get(context.Background(), "id")
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, int32(1), calls.Load())
+		assert.NoError(t, c.Close())
+	})
+	t.Run("retry is bounded under repeated aborts", func(t *testing.T) {
+		// White-box: a pre-poisoned entry (failed, aborted, never removed
+		// from the map — unlike a real load) makes every retry observe the
+		// same aborted result, so Get must give up at maxLoadRetries
+		// instead of spinning.
+		c := New(func(ctx context.Context, id string) (Object, error) {
+			return &testObject{name: id}, nil
+		}).(*oCache)
+		e := newEntry("id", nil, entryStateLoading)
+		e.loadErr = context.Canceled
+		e.loadAborted = true
+		close(e.load)
+		c.mu.Lock()
+		c.data["id"] = e
+		c.mu.Unlock()
+		_, err := c.Get(context.Background(), "id")
+		require.ErrorIs(t, err, context.Canceled)
+		c.mu.Lock()
+		delete(c.data, "id")
+		c.mu.Unlock()
+		assert.NoError(t, c.Close())
+	})
+	t.Run("no retry when the caller's own ctx is done", func(t *testing.T) {
+		var calls atomic.Int32
+		c := New(func(ctx context.Context, id string) (Object, error) {
+			calls.Add(1)
+			return nil, ctx.Err()
+		})
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := c.Get(cctx, "id")
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, int32(1), calls.Load())
+		assert.NoError(t, c.Close())
+	})
+}
+
 func TestOCache_GC(t *testing.T) {
 	t.Run("test gc expired object", func(t *testing.T) {
 		c := New(func(ctx context.Context, id string) (value Object, err error) {
@@ -487,7 +583,10 @@ func TestOCacheCancelWhenRemove(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 	c.Close()
 	<-stopLoad
-	require.Equal(t, context.Canceled, err)
+	// Close cancels the in-flight load; the caller's retry then observes
+	// the closed cache and reports ErrClosed — the actual reason — rather
+	// than the load's raw context.Canceled.
+	require.Equal(t, ErrClosed, err)
 }
 
 func TestOCacheFuzzy(t *testing.T) {


### PR DESCRIPTION
## Problem

`ocache.Get` runs a load under the context of whichever caller arrived first and shares the result — including the error — with every concurrent waiter. When that first caller goes away mid-load (its request finished, a per-round timeout fired), the load dies with `context.Canceled` and every waiter inherits an error that has nothing to do with its own, still-live context.

The peer pool makes this bite in practice: dials are ocache loads keyed by peerId, so a dial owned by a short-lived background context (e.g. a headsync round that completes mid-dial) poisons the same dial for a concurrent space pull. `getSpaceStorageFromRemote` retries only `net.ErrUnableToConnect`, so the foreign cancellation surfaces as a hard `NewSpace: context canceled`. Observed as an intermittent (~2 in 5) client-side `Get` failure right after a space appears in the account index, during the boot window when node connections churn.

## Fix

`load()` records whether the load's **own** context was already done when the loadFunc returned (`entry.loadAborted`) — the precise signal that the load was *killed* rather than *refused*. `Get` retries an aborted load for callers whose own ctx is still alive: the failed entry is already deleted, so the retry starts a fresh load owned by a live context. Bounded by `maxLoadRetries` (3) against abort storms.

Deliberately **not** error-shape based: a loadFunc-internal timeout (e.g. yamux/quic dial deadline) returns `context.DeadlineExceeded` with the load ctx alive — that is a verdict about the resource and is never retried, so dials to a dead peer still fail in a single attempt. Callers whose own ctx is done never retry, and an abandoned load with no waiters still dies with its owner. `Get`'s body is restructured as a loop (replacing the `goto`) and the hit/miss metric now counts once per logical `Get`.

## Behavior change

A `Get` in flight while the cache **closes** now reports `ErrClosed` (the actual reason) instead of the load's raw `context.Canceled` — the retry observes the closed cache. `TestOCacheCancelWhenRemove` updated accordingly.

Known scope limit: `Pick` and the `remove()`/`Close` wait paths can still surface a foreign context error for a poisoned in-flight load; only `Get` heals, since it is the only path that can restart a load.

## Testing

- New tests: waiter survives the first caller's cancellation; loadFunc-internal timeouts are not retried (single attempt); retry cap terminates under repeated aborts; no retry when the caller's own ctx is done.
- `go test ./... -count=1` green; `./app/ocache` green under `-race`.
- End-to-end against the staging network via the any-sync-sdk e2e suite with a local `replace`: the previously flaky `TestE2E_Payloads` (device-B `Get` right after space discovery, ~60% pass rate) passed 13/13 runs with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)