### PR TITLE
feat(payments): add paymentUrl to MembershipV2.Invoice

### DIFF
--- a/paymentservice/paymentserviceproto/paymentservice2.pb.go
+++ b/paymentservice/paymentserviceproto/paymentservice2.pb.go
@@ -944,11 +944,15 @@ func (x *MembershipV2_CartProduct) GetIsLifetime() bool {
 }
 
 type MembershipV2_Invoice struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	Id            string                      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Date          uint64                      `protobuf:"varint,2,opt,name=date,proto3" json:"date,omitempty"`
-	Total         *MembershipV2_Amount        `protobuf:"bytes,3,opt,name=total,proto3" json:"total,omitempty"`
-	Status        MembershipV2_Invoice_Status `protobuf:"varint,4,opt,name=status,proto3,enum=MembershipV2_Invoice_Status" json:"status,omitempty"`
+	state  protoimpl.MessageState      `protogen:"open.v1"`
+	Id     string                      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Date   uint64                      `protobuf:"varint,2,opt,name=date,proto3" json:"date,omitempty"`
+	Total  *MembershipV2_Amount        `protobuf:"bytes,3,opt,name=total,proto3" json:"total,omitempty"`
+	Status MembershipV2_Invoice_Status `protobuf:"varint,4,opt,name=status,proto3,enum=MembershipV2_Invoice_Status" json:"status,omitempty"`
+	// Stripe hosted-invoice payment page for an OPEN (unpaid) invoice the user
+	// must pay to keep access — set during the reverse-trial grace period.
+	// Empty when no action is required.
+	PaymentUrl    string `protobuf:"bytes,5,opt,name=paymentUrl,proto3" json:"paymentUrl,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1009,6 +1013,13 @@ func (x *MembershipV2_Invoice) GetStatus() MembershipV2_Invoice_Status {
 		return x.Status
 	}
 	return MembershipV2_Invoice_Unpaid
+}
+
+func (x *MembershipV2_Invoice) GetPaymentUrl() string {
+	if x != nil {
+		return x.PaymentUrl
+	}
+	return ""
 }
 
 type MembershipV2_Cart struct {
@@ -2089,7 +2100,7 @@ var File_paymentservice_paymentserviceproto_protos_paymentservice2_proto protore
 
 const file_paymentservice_paymentserviceproto_protos_paymentservice2_proto_rawDesc = "" +
 	"\n" +
-	"?paymentservice/paymentserviceproto/protos/paymentservice2.proto\"\xf3\x1f\n" +
+	"?paymentservice/paymentserviceproto/protos/paymentservice2.proto\"\x93 \n" +
 	"\fMembershipV2\x1aF\n" +
 	"\x06Amount\x12\x1a\n" +
 	"\bcurrency\x18\x01 \x01(\tR\bcurrency\x12 \n" +
@@ -2142,12 +2153,15 @@ const file_paymentservice_paymentserviceproto_protos_paymentservice2_proto_rawDe
 	"\x06remove\x18\x03 \x01(\bR\x06remove\x12\x1e\n" +
 	"\n" +
 	"isLifetime\x18\x04 \x01(\bR\n" +
-	"isLifetime\x1a\xaf\x01\n" +
+	"isLifetime\x1a\xcf\x01\n" +
 	"\aInvoice\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04date\x18\x02 \x01(\x04R\x04date\x12*\n" +
 	"\x05total\x18\x03 \x01(\v2\x14.MembershipV2.AmountR\x05total\x124\n" +
-	"\x06status\x18\x04 \x01(\x0e2\x1c.MembershipV2.Invoice.StatusR\x06status\"\x1e\n" +
+	"\x06status\x18\x04 \x01(\x0e2\x1c.MembershipV2.Invoice.StatusR\x06status\x12\x1e\n" +
+	"\n" +
+	"paymentUrl\x18\x05 \x01(\tR\n" +
+	"paymentUrl\"\x1e\n" +
 	"\x06Status\x12\n" +
 	"\n" +
 	"\x06Unpaid\x10\x00\x12\b\n" +

--- a/paymentservice/paymentserviceproto/paymentservice2_vtproto.pb.go
+++ b/paymentservice/paymentserviceproto/paymentservice2_vtproto.pb.go
@@ -552,6 +552,13 @@ func (m *MembershipV2_Invoice) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.PaymentUrl) > 0 {
+		i -= len(m.PaymentUrl)
+		copy(dAtA[i:], m.PaymentUrl)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PaymentUrl)))
+		i--
+		dAtA[i] = 0x2a
+	}
 	if m.Status != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Status))
 		i--
@@ -1831,6 +1838,10 @@ func (m *MembershipV2_Invoice) SizeVT() (n int) {
 	}
 	if m.Status != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Status))
+	}
+	l = len(m.PaymentUrl)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -3579,6 +3590,38 @@ func (m *MembershipV2_Invoice) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PaymentUrl", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PaymentUrl = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/paymentservice/paymentserviceproto/protos/paymentservice2.proto
+++ b/paymentservice/paymentserviceproto/protos/paymentservice2.proto
@@ -128,6 +128,10 @@ message MembershipV2 {
     uint64 date = 2;
     Amount total = 3;
     Status status = 4;
+    // Stripe hosted-invoice payment page for an OPEN (unpaid) invoice the user
+    // must pay to keep access — set during the reverse-trial grace period.
+    // Empty when no action is required.
+    string paymentUrl = 5;
   }
 
   message Cart {


### PR DESCRIPTION
## Add `paymentUrl` to `MembershipV2.Invoice`

Adds a new optional field to the nested `MembershipV2.Invoice` message:

```proto
string paymentUrl = 5;
```

It carries the Stripe **hosted-invoice payment page** URL for an OPEN (unpaid) invoice the user must pay to keep access — set during the payment-processing node's reverse-trial grace period, empty when no action is required.

### Why

any-pp-node's new reverse-trial flow needs to hand a user to Stripe's hosted invoice page when a trial ends unpaid. Status responses expose that URL through this field. Consumer PR: anyproto/any-pp-node#109.

### Compatibility

- **Wire-backward-compatible**: additive field, tag `5` was previously free on `MembershipV2.Invoice` (fields 1–4 in use). Empty/absent preserves current behavior for desktop/heart, which ignore it.
- Regenerated `.pb.go` + `_vtproto.pb.go` are included (marshal/unmarshal/size for field 5).

### Backport

This targets `main`. It also needs to land on **`v0.13.x`** (the line carrying `dateTrialEnds` that any-pp-node pins against) — @requilence will cherry-pick the merge commit there manually. `main` and `v0.13.x` had byte-identical `paymentservice2.proto` + generated files before this change, so the cherry-pick applies cleanly.
