### PR TITLE
feat(payments): add billingReason to MembershipV2.Invoice

### DIFF
--- a/paymentservice/paymentserviceproto/paymentservice2.pb.go
+++ b/paymentservice/paymentserviceproto/paymentservice2.pb.go
@@ -952,7 +952,13 @@ type MembershipV2_Invoice struct {
 	// Stripe hosted-invoice payment page for an OPEN (unpaid) invoice the user
 	// must pay to keep access — set during the reverse-trial grace period.
 	// Empty when no action is required.
-	PaymentUrl    string `protobuf:"bytes,5,opt,name=paymentUrl,proto3" json:"paymentUrl,omitempty"`
+	PaymentUrl string `protobuf:"bytes,5,opt,name=paymentUrl,proto3" json:"paymentUrl,omitempty"`
+	// Stripe billing_reason of the OPEN invoice this record describes, verbatim
+	// (e.g. "subscription_cycle" for the first post-trial invoice,
+	// "subscription_update"/"subscription_threshold" for later renewal dunning).
+	// Lets a consumer tell a trial-ended grace invoice from a failed-renewal one
+	// exactly, instead of inferring it from period math. Empty when unknown.
+	BillingReason string `protobuf:"bytes,6,opt,name=billingReason,proto3" json:"billingReason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1018,6 +1024,13 @@ func (x *MembershipV2_Invoice) GetStatus() MembershipV2_Invoice_Status {
 func (x *MembershipV2_Invoice) GetPaymentUrl() string {
 	if x != nil {
 		return x.PaymentUrl
+	}
+	return ""
+}
+
+func (x *MembershipV2_Invoice) GetBillingReason() string {
+	if x != nil {
+		return x.BillingReason
 	}
 	return ""
 }
@@ -2100,7 +2113,7 @@ var File_paymentservice_paymentserviceproto_protos_paymentservice2_proto protore
 
 const file_paymentservice_paymentserviceproto_protos_paymentservice2_proto_rawDesc = "" +
 	"\n" +
-	"?paymentservice/paymentserviceproto/protos/paymentservice2.proto\"\x93 \n" +
+	"?paymentservice/paymentserviceproto/protos/paymentservice2.proto\"\xb9 \n" +
 	"\fMembershipV2\x1aF\n" +
 	"\x06Amount\x12\x1a\n" +
 	"\bcurrency\x18\x01 \x01(\tR\bcurrency\x12 \n" +
@@ -2153,7 +2166,7 @@ const file_paymentservice_paymentserviceproto_protos_paymentservice2_proto_rawDe
 	"\x06remove\x18\x03 \x01(\bR\x06remove\x12\x1e\n" +
 	"\n" +
 	"isLifetime\x18\x04 \x01(\bR\n" +
-	"isLifetime\x1a\xcf\x01\n" +
+	"isLifetime\x1a\xf5\x01\n" +
 	"\aInvoice\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04date\x18\x02 \x01(\x04R\x04date\x12*\n" +
@@ -2161,7 +2174,8 @@ const file_paymentservice_paymentserviceproto_protos_paymentservice2_proto_rawDe
 	"\x06status\x18\x04 \x01(\x0e2\x1c.MembershipV2.Invoice.StatusR\x06status\x12\x1e\n" +
 	"\n" +
 	"paymentUrl\x18\x05 \x01(\tR\n" +
-	"paymentUrl\"\x1e\n" +
+	"paymentUrl\x12$\n" +
+	"\rbillingReason\x18\x06 \x01(\tR\rbillingReason\"\x1e\n" +
 	"\x06Status\x12\n" +
 	"\n" +
 	"\x06Unpaid\x10\x00\x12\b\n" +

--- a/paymentservice/paymentserviceproto/paymentservice2_vtproto.pb.go
+++ b/paymentservice/paymentserviceproto/paymentservice2_vtproto.pb.go
@@ -552,6 +552,13 @@ func (m *MembershipV2_Invoice) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.BillingReason) > 0 {
+		i -= len(m.BillingReason)
+		copy(dAtA[i:], m.BillingReason)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BillingReason)))
+		i--
+		dAtA[i] = 0x32
+	}
 	if len(m.PaymentUrl) > 0 {
 		i -= len(m.PaymentUrl)
 		copy(dAtA[i:], m.PaymentUrl)
@@ -1840,6 +1847,10 @@ func (m *MembershipV2_Invoice) SizeVT() (n int) {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Status))
 	}
 	l = len(m.PaymentUrl)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.BillingReason)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -3621,6 +3632,38 @@ func (m *MembershipV2_Invoice) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.PaymentUrl = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BillingReason", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BillingReason = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/paymentservice/paymentserviceproto/protos/paymentservice2.proto
+++ b/paymentservice/paymentserviceproto/protos/paymentservice2.proto
@@ -132,6 +132,12 @@ message MembershipV2 {
     // must pay to keep access — set during the reverse-trial grace period.
     // Empty when no action is required.
     string paymentUrl = 5;
+    // Stripe billing_reason of the OPEN invoice this record describes, verbatim
+    // (e.g. "subscription_cycle" for the first post-trial invoice,
+    // "subscription_update"/"subscription_threshold" for later renewal dunning).
+    // Lets a consumer tell a trial-ended grace invoice from a failed-renewal one
+    // exactly, instead of inferring it from period math. Empty when unknown.
+    string billingReason = 6;
   }
 
   message Cart {


### PR DESCRIPTION
## Summary

Adds `billingReason` (field 6) to the nested `MembershipV2.Invoice` message in the payment service v2 proto. It carries the verbatim Stripe `billing_reason` of the open invoice a status response describes.

## Why

A consumer classifying an in-grace subscription needs to tell a **trial-ended grace** invoice (Stripe `billing_reason=subscription_cycle` — the first post-trial charge) from a **failed-renewal** one (a later cycle). Today ee-cloud infers this from `CurrentPeriodEnd - TrialEnd` period math (a heuristic that absorbs month-length/leap variance). Exposing the invoice's `billing_reason` makes the classification exact.

Producer (any-pp-node) stamps it from the open invoice during the reverse-trial grace window; see the companion pp-node PR.

## Changes

- `paymentservice2.proto`: `string billingReason = 6;` on `MembershipV2.Invoice`.
- Regenerated `paymentservice2.pb.go` + `paymentservice2_vtproto.pb.go` (protoc-gen-go v1.36.11 + vtprotobuf).

## Compatibility

Additive, wire-backward-compatible. Empty/absent preserves current behavior for all existing consumers (desktop, heart). No service/RPC surface change.

## Notes on generated files

Only `paymentservice2.pb.go` / `_vtproto.pb.go` are included. A no-op regen on this toolchain also rewrites the `_drpc`/`tiers`/version-comment lines of the other paymentservice files (protoc v6.33.0->v6.33.4, protoc-gen-go-drpc v0.0.34->v1.0.0) — that churn is unrelated to this change and was deliberately excluded.

## Testing

`go build ./paymentservice/...` clean.