### PR TITLE
crypto: error on ciphertext shorter than GCM nonce in DecryptReuse

### DIFF
--- a/util/crypto/aes.go
+++ b/util/crypto/aes.go
@@ -123,6 +123,9 @@ func (k *AESKey) Decrypt(ciphertext []byte) ([]byte, error) {
 
 // DecryptReuse is like Decrypt but reuses dst's underlying array to avoid allocation.
 func (k *AESKey) DecryptReuse(dst, ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) < NonceBytes {
+		return nil, fmt.Errorf("ciphertext too short: %d bytes, need at least %d", len(ciphertext), NonceBytes)
+	}
 	block, err := aes.NewCipher(k.raw[:KeyBytes])
 	if err != nil {
 		return nil, err

--- a/util/crypto/aes_test.go
+++ b/util/crypto/aes_test.go
@@ -43,6 +43,18 @@ func TestAESKey_DecryptReuse_NilDst(t *testing.T) {
 	require.Equal(t, msg, result)
 }
 
+func TestAESKey_Decrypt_ShortInput(t *testing.T) {
+	key := NewAES()
+	// wire-controlled input shorter than the GCM nonce must error, not panic
+	for l := 0; l < NonceBytes; l++ {
+		_, err := key.Decrypt(make([]byte, l))
+		require.Error(t, err, "len %d", l)
+	}
+	// nonce-only input has no room for the GCM tag: auth error, not panic
+	_, err := key.Decrypt(make([]byte, NonceBytes))
+	require.Error(t, err)
+}
+
 func TestAESKey_DecryptReuse_BufferReuse(t *testing.T) {
 	key := NewAES()
 	msg := make([]byte, 256)


### PR DESCRIPTION
`AESKey.DecryptReuse` slices `ciphertext[:NonceBytes]` unconditionally, so any input shorter than the 12-byte GCM nonce panics with `slice bounds out of range` instead of returning an error. The input is wire-controlled (e.g. an identityRepo record), so a malformed or legacy record crashes the whole process — see SYN-94: a 6-byte legacy plaintext profile blob crash-loops every boot of an affected account.

Fix: return an error when `len(ciphertext) < NonceBytes`. Inputs ≥ 12 bytes were already safe — `aesgcm.Open` fails auth and returns an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)