### PR TITLE
peerservice: prefer yamux for local addresses

### DIFF
--- a/net/peerservice/localaddr.go
+++ b/net/peerservice/localaddr.go
@@ -1,0 +1,86 @@
+package peerservice
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	// localResolveTimeout bounds the hostname lookup used only to order dial
+	// candidates. Locally answered names (hosts file, docker embedded DNS,
+	// mDNS cache, LAN resolver) reply within a few milliseconds; a lookup
+	// that needs upstream recursion misses the budget and the address is
+	// treated as non-local. The verdict only affects ordering — every
+	// address is still dialed — so guessing wrong is cheap.
+	localResolveTimeout = 200 * time.Millisecond
+	localResolveTTL     = time.Minute
+	localCacheMaxSize   = 128
+)
+
+type localVerdict struct {
+	local   bool
+	expires time.Time
+}
+
+// localAddrDetector reports whether an address points at the local network:
+// loopback, RFC1918/ULA private ranges, or link-local. Hostnames are resolved
+// with a short deadline and the verdict is cached.
+type localAddrDetector struct {
+	mu      sync.Mutex
+	cache   map[string]localVerdict
+	resolve func(ctx context.Context, host string) ([]net.IPAddr, error)
+	now     func() time.Time
+}
+
+func newLocalAddrDetector() *localAddrDetector {
+	return &localAddrDetector{
+		cache:   map[string]localVerdict{},
+		resolve: net.DefaultResolver.LookupIPAddr,
+		now:     time.Now,
+	}
+}
+
+func isLocalIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}
+
+// isLocal takes a hostport (scheme already stripped) and classifies its host.
+func (d *localAddrDetector) isLocal(ctx context.Context, hostport string) bool {
+	host, _, err := net.SplitHostPort(hostport)
+	if err != nil {
+		host = hostport
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return isLocalIP(ip)
+	}
+
+	now := d.now()
+	d.mu.Lock()
+	if v, ok := d.cache[host]; ok && now.Before(v.expires) {
+		d.mu.Unlock()
+		return v.local
+	}
+	d.mu.Unlock()
+
+	rctx, cancel := context.WithTimeout(ctx, localResolveTimeout)
+	defer cancel()
+	var local bool
+	if ips, err := d.resolve(rctx, host); err == nil {
+		for _, ip := range ips {
+			if isLocalIP(ip.IP) {
+				local = true
+				break
+			}
+		}
+	}
+
+	d.mu.Lock()
+	if len(d.cache) >= localCacheMaxSize {
+		d.cache = map[string]localVerdict{}
+	}
+	d.cache[host] = localVerdict{local: local, expires: now.Add(localResolveTTL)}
+	d.mu.Unlock()
+	return local
+}

--- a/net/peerservice/localaddr.go
+++ b/net/peerservice/localaddr.go
@@ -3,6 +3,7 @@ package peerservice
 import (
 	"context"
 	"net"
+	"strings"
 	"sync"
 	"time"
 )
@@ -16,7 +17,10 @@ const (
 	// address is still dialed — so guessing wrong is cheap.
 	localResolveTimeout = 200 * time.Millisecond
 	localResolveTTL     = time.Minute
-	localCacheMaxSize   = 128
+	// failed lookups keep a short TTL: DNS being briefly down (network just
+	// came up, captive portal) must not pin a wrong verdict for a minute
+	localResolveErrTTL = 5 * time.Second
+	localCacheMaxSize  = 128
 )
 
 type localVerdict struct {
@@ -55,6 +59,12 @@ func (d *localAddrDetector) isLocal(ctx context.Context, hostport string) bool {
 	if ip := net.ParseIP(host); ip != nil {
 		return isLocalIP(ip)
 	}
+	// zoned IPv6 literal (fe80::1%en0) — ParseIP can't handle the zone
+	if i := strings.IndexByte(host, '%'); i != -1 {
+		if ip := net.ParseIP(host[:i]); ip != nil {
+			return isLocalIP(ip)
+		}
+	}
 
 	now := d.now()
 	d.mu.Lock()
@@ -67,6 +77,7 @@ func (d *localAddrDetector) isLocal(ctx context.Context, hostport string) bool {
 	rctx, cancel := context.WithTimeout(ctx, localResolveTimeout)
 	defer cancel()
 	var local bool
+	ttl := localResolveTTL
 	if ips, err := d.resolve(rctx, host); err == nil {
 		for _, ip := range ips {
 			if isLocalIP(ip.IP) {
@@ -74,13 +85,20 @@ func (d *localAddrDetector) isLocal(ctx context.Context, hostport string) bool {
 				break
 			}
 		}
+	} else {
+		if ctx.Err() != nil {
+			// the lookup lost to the caller's dial budget, not to DNS —
+			// don't record a verdict at all
+			return false
+		}
+		ttl = localResolveErrTTL
 	}
 
 	d.mu.Lock()
 	if len(d.cache) >= localCacheMaxSize {
 		d.cache = map[string]localVerdict{}
 	}
-	d.cache[host] = localVerdict{local: local, expires: now.Add(localResolveTTL)}
+	d.cache[host] = localVerdict{local: local, expires: now.Add(ttl)}
 	d.mu.Unlock()
 	return local
 }

--- a/net/peerservice/localaddr_test.go
+++ b/net/peerservice/localaddr_test.go
@@ -1,0 +1,105 @@
+package peerservice
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLocalAddrDetector_IPLiterals(t *testing.T) {
+	d := newLocalAddrDetector()
+	d.resolve = func(_ context.Context, host string) ([]net.IPAddr, error) {
+		t.Fatalf("unexpected resolve of %q for an ip literal", host)
+		return nil, nil
+	}
+
+	for _, tc := range []struct {
+		hostport string
+		local    bool
+	}{
+		{"127.0.0.1:1111", true},
+		{"[::1]:4242", true},
+		{"::1", true},
+		{"192.168.1.5:4242", true},
+		{"10.0.0.7:1", true},
+		{"172.18.0.5:1001", true},
+		{"[::ffff:192.168.1.5]:4242", true},
+		{"[fd00::1]:4242", true},
+		{"169.254.1.2:1", true},
+		{"[fe80::1%en0]:4242", true},
+		{"203.0.113.1:443", false},
+		{"8.8.8.8:53", false},
+		{"100.64.1.2:4242", false}, // CGNAT (tailscale) — deliberately non-local
+		{"0.0.0.0:1", false},
+	} {
+		assert.Equal(t, tc.local, d.isLocal(ctx, tc.hostport), tc.hostport)
+	}
+}
+
+func TestLocalAddrDetector_Hostnames(t *testing.T) {
+	t.Run("verdict expires after ttl", func(t *testing.T) {
+		d := newLocalAddrDetector()
+		now := time.Now()
+		d.now = func() time.Time { return now }
+		var calls int
+		d.resolve = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			calls++
+			return []net.IPAddr{{IP: net.ParseIP("192.168.1.10")}}, nil
+		}
+
+		assert.True(t, d.isLocal(ctx, "box.lan:1111"))
+		assert.True(t, d.isLocal(ctx, "box.lan:1111"))
+		assert.Equal(t, 1, calls)
+
+		now = now.Add(localResolveTTL + time.Second)
+		assert.True(t, d.isLocal(ctx, "box.lan:1111"))
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("failed lookup gets short ttl", func(t *testing.T) {
+		d := newLocalAddrDetector()
+		now := time.Now()
+		d.now = func() time.Time { return now }
+		var calls int
+		d.resolve = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			calls++
+			if calls == 1 {
+				return nil, fmt.Errorf("dns unavailable")
+			}
+			return []net.IPAddr{{IP: net.ParseIP("192.168.1.10")}}, nil
+		}
+
+		assert.False(t, d.isLocal(ctx, "box.lan:1111"))
+		now = now.Add(localResolveErrTTL + time.Second)
+		assert.True(t, d.isLocal(ctx, "box.lan:1111"))
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("caller-canceled lookup is not cached", func(t *testing.T) {
+		d := newLocalAddrDetector()
+		d.resolve = func(rctx context.Context, _ string) ([]net.IPAddr, error) {
+			return nil, rctx.Err()
+		}
+		canceled, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		assert.False(t, d.isLocal(canceled, "box.lan:1111"))
+
+		d.resolve = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("192.168.1.10")}}, nil
+		}
+		assert.True(t, d.isLocal(ctx, "box.lan:1111"))
+	})
+
+	t.Run("public hostname is not local", func(t *testing.T) {
+		d := newLocalAddrDetector()
+		d.resolve = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("142.250.185.78")}}, nil
+		}
+		assert.False(t, d.isLocal(ctx, "example.org:443"))
+	})
+}

--- a/net/peerservice/peerservice.go
+++ b/net/peerservice/peerservice.go
@@ -136,12 +136,19 @@ func (p *peerService) Dial(ctx context.Context, peerId string) (pr peer.Peer, er
 	}
 	connPeerId, err := peer.CtxPeerId(mc.Context())
 	if err != nil {
+		_ = mc.Close()
 		return nil, err
 	}
 	if connPeerId != peerId {
+		_ = mc.Close()
 		return nil, ErrPeerIdMismatched
 	}
-	return peer.NewPeer(mc, p.server)
+	pr, err = peer.NewPeer(mc, p.server)
+	if err != nil {
+		_ = mc.Close()
+		return nil, err
+	}
+	return pr, nil
 }
 
 // orderAddrs returns the dial candidates in preference order, dropping addrs

--- a/net/peerservice/peerservice.go
+++ b/net/peerservice/peerservice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -50,6 +51,7 @@ type peerService struct {
 	pool         pool.Pool
 	server       server.DRPCServer
 	preferQuic   bool
+	localAddrs   *localAddrDetector
 	mu           sync.RWMutex
 }
 
@@ -70,12 +72,13 @@ func (p *peerService) Init(a *app.App) (err error) {
 	p.pool = a.MustComponent(pool.CName).(pool.Pool)
 	p.server = a.MustComponent(server.CName).(server.DRPCServer)
 	p.peerAddrs = map[string][]string{}
+	p.localAddrs = newLocalAddrDetector()
 	return nil
 }
 
-func (p *peerService) preferredSchemes() []string {
+func (p *peerService) preferredSchemes(preferQuic bool) []string {
 	var schemes []string
-	if p.preferQuic {
+	if preferQuic {
 		if p.quic != nil {
 			schemes = append(schemes, transport.Quic)
 		}
@@ -108,23 +111,23 @@ func (p *peerService) PreferQuic(prefer bool) {
 
 func (p *peerService) Dial(ctx context.Context, peerId string) (pr peer.Peer, err error) {
 	p.mu.RLock()
-	schemes := p.preferredSchemes()
+	preferQuic := p.preferQuic
 	addrs, err := p.getPeerAddrs(peerId)
+	p.mu.RUnlock()
 	if err != nil {
-		p.mu.RUnlock()
 		return
 	}
-	p.mu.RUnlock()
 
 	// Pass expected peerId in context for transports that need it (e.g. WebTransport)
 	ctx = peer.CtxWithExpectedPeerId(ctx, peerId)
 
-	var mc transport.MultiConn
-	log.DebugCtx(ctx, "dial", zap.String("peerId", peerId), zap.Strings("addrs", addrs))
+	ordered := p.orderAddrs(ctx, addrs, preferQuic)
+	log.DebugCtx(ctx, "dial", zap.String("peerId", peerId), zap.Strings("addrs", ordered))
 
+	var mc transport.MultiConn
 	err = ErrAddrsNotFound
-	for _, sch := range schemes {
-		if mc, err = p.dialScheme(ctx, sch, addrs); err == nil {
+	for _, addr := range ordered {
+		if mc, err = p.dialAddr(ctx, addr); err == nil {
 			break
 		}
 	}
@@ -141,34 +144,61 @@ func (p *peerService) Dial(ctx context.Context, peerId string) (pr peer.Peer, er
 	return peer.NewPeer(mc, p.server)
 }
 
-func (p *peerService) dialScheme(ctx context.Context, sch string, addrs []string) (mc transport.MultiConn, err error) {
-	var tr transport.Transport
-	switch sch {
-	case transport.Quic:
-		tr = p.quic
-	case transport.Yamux:
-		tr = p.yamux
-	case transport.WebTransport:
-		tr = p.webtransport
-	default:
-		return nil, fmt.Errorf("unexpected transport: %v", sch)
+// orderAddrs returns the dial candidates in preference order, dropping addrs
+// whose scheme has no registered transport. The scheme order is decided per
+// address: local addresses (loopback/private/link-local, hostnames resolved
+// with a short deadline) always try yamux first — a dead port answers a TCP
+// dial with an RST in one RTT, while a QUIC dial has to wait out the whole
+// handshake timeout, because quic-go gets no ICMP feedback on the unconnected
+// sockets used for dialing. Non-local addresses follow the global preferQuic
+// order. The sort is stable, so the given order is kept within equal
+// preference — and with preferQuic unset the order is unchanged, since yamux
+// comes first either way.
+func (p *peerService) orderAddrs(ctx context.Context, addrs []string, preferQuic bool) []string {
+	type candidate struct {
+		addr string
+		rank int
 	}
-	if tr == nil {
-		return nil, fmt.Errorf("transport %v not available", sch)
-	}
-
-	err = ErrAddrsNotFound
+	candidates := make([]candidate, 0, len(addrs))
 	for _, addr := range addrs {
-		if scheme(addr) != sch {
+		schemes := p.preferredSchemes(preferQuic && !p.localAddrs.isLocal(ctx, stripScheme(addr)))
+		rank := slices.Index(schemes, scheme(addr))
+		if rank == -1 {
 			continue
 		}
-		if mc, err = tr.Dial(ctx, stripScheme(addr)); err == nil {
-			return
-		} else {
-			log.InfoCtx(ctx, "can't connect to host", zap.String("addr", addr), zap.Error(err))
-		}
+		candidates = append(candidates, candidate{addr: addr, rank: rank})
+	}
+	slices.SortStableFunc(candidates, func(a, b candidate) int {
+		return a.rank - b.rank
+	})
+	ordered := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		ordered = append(ordered, c.addr)
+	}
+	return ordered
+}
+
+func (p *peerService) dialAddr(ctx context.Context, addr string) (mc transport.MultiConn, err error) {
+	tr := p.transport(scheme(addr))
+	if tr == nil {
+		return nil, fmt.Errorf("transport %v not available", scheme(addr))
+	}
+	if mc, err = tr.Dial(ctx, stripScheme(addr)); err != nil {
+		log.InfoCtx(ctx, "can't connect to host", zap.String("addr", addr), zap.Error(err))
 	}
 	return
+}
+
+func (p *peerService) transport(sch string) transport.Transport {
+	switch sch {
+	case transport.Quic:
+		return p.quic
+	case transport.Yamux:
+		return p.yamux
+	case transport.WebTransport:
+		return p.webtransport
+	}
+	return nil
 }
 
 func (p *peerService) Accept(mc transport.MultiConn) (err error) {

--- a/net/peerservice/peerservice_test.go
+++ b/net/peerservice/peerservice_test.go
@@ -193,6 +193,27 @@ func TestPeerService_DialLocalAddrs(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, p)
 	})
+	t.Run("servers never resolve: preferQuic unset short-circuits the local check", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		fx.PreferQuic(false)
+		var peerId = "p1"
+
+		fx.setResolver(func(_ context.Context, host string) ([]net.IPAddr, error) {
+			t.Fatalf("resolver must not run with preferQuic=false, got lookup of %q", host)
+			return nil, nil
+		})
+		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return([]string{
+			"yamux://any-sync-node-1:1111",
+			"quic://any-sync-node-1:1112",
+		}, true)
+
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "any-sync-node-1:1111").Return(fx.mockMC(peerId), nil)
+
+		p, err := fx.Dial(ctx, peerId)
+		require.NoError(t, err)
+		assert.NotNil(t, p)
+	})
 	t.Run("hostname verdict is cached", func(t *testing.T) {
 		fx := newFixture(t)
 		defer fx.finish(t)

--- a/net/peerservice/peerservice_test.go
+++ b/net/peerservice/peerservice_test.go
@@ -3,6 +3,7 @@ package peerservice
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/anyproto/any-sync/app"
@@ -24,9 +25,10 @@ import (
 var ctx = context.Background()
 
 func TestPeerService_Dial(t *testing.T) {
+	// public (non-local) addrs: the global preferQuic order applies
 	var addrs = []string{
-		"yamux://127.0.0.1:1111",
-		"quic://127.0.0.1:1112",
+		"yamux://203.0.113.1:1111",
+		"quic://203.0.113.1:1112",
 	}
 	t.Run("prefer yamux", func(t *testing.T) {
 		fx := newFixture(t)
@@ -36,7 +38,7 @@ func TestPeerService_Dial(t *testing.T) {
 
 		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return(addrs, true)
 
-		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "127.0.0.1:1111").Return(fx.mockMC(peerId), nil)
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "203.0.113.1:1111").Return(fx.mockMC(peerId), nil)
 
 		p, err := fx.Dial(ctx, peerId)
 		require.NoError(t, err)
@@ -50,7 +52,7 @@ func TestPeerService_Dial(t *testing.T) {
 
 		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return(addrs, true)
 
-		fx.quic.MockTransport.EXPECT().Dial(gomock.Any(), "127.0.0.1:1112").Return(fx.mockMC(peerId), nil)
+		fx.quic.MockTransport.EXPECT().Dial(gomock.Any(), "203.0.113.1:1112").Return(fx.mockMC(peerId), nil)
 
 		p, err := fx.Dial(ctx, peerId)
 		require.NoError(t, err)
@@ -64,8 +66,8 @@ func TestPeerService_Dial(t *testing.T) {
 
 		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return(addrs, true)
 
-		fx.quic.MockTransport.EXPECT().Dial(gomock.Any(), "127.0.0.1:1112").Return(nil, fmt.Errorf("test"))
-		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "127.0.0.1:1111").Return(fx.mockMC(peerId), nil)
+		fx.quic.MockTransport.EXPECT().Dial(gomock.Any(), "203.0.113.1:1112").Return(nil, fmt.Errorf("test"))
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "203.0.113.1:1111").Return(fx.mockMC(peerId), nil)
 
 		p, err := fx.Dial(ctx, peerId)
 		require.NoError(t, err)
@@ -79,7 +81,7 @@ func TestPeerService_Dial(t *testing.T) {
 
 		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return(addrs, true)
 
-		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "127.0.0.1:1111").Return(fx.mockMC(peerId+"not valid"), nil)
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "203.0.113.1:1111").Return(fx.mockMC(peerId+"not valid"), nil)
 
 		p, err := fx.Dial(ctx, peerId)
 		assert.EqualError(t, err, ErrPeerIdMismatched.Error())
@@ -94,7 +96,7 @@ func TestPeerService_Dial(t *testing.T) {
 		fx.SetPeerAddrs(peerId, addrs)
 		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return(nil, false)
 
-		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "127.0.0.1:1111").Return(fx.mockMC(peerId), nil)
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "203.0.113.1:1111").Return(fx.mockMC(peerId), nil)
 
 		p, err := fx.Dial(ctx, peerId)
 		require.NoError(t, err)
@@ -113,6 +115,104 @@ func TestPeerService_Dial(t *testing.T) {
 		p, err := fx.Dial(ctx, peerId)
 		require.NoError(t, err)
 		assert.NotNil(t, p)
+	})
+}
+
+func TestPeerService_DialLocalAddrs(t *testing.T) {
+	var localAddrs = []string{
+		"quic://192.168.1.5:1112",
+		"yamux://192.168.1.5:1111",
+	}
+	t.Run("local addr prefers yamux even when quic preferred", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		fx.PreferQuic(true)
+		var peerId = "p1"
+
+		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return(localAddrs, true)
+
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "192.168.1.5:1111").Return(fx.mockMC(peerId), nil)
+
+		p, err := fx.Dial(ctx, peerId)
+		require.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+	t.Run("local addr falls back to quic when yamux fails", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		fx.PreferQuic(true)
+		var peerId = "p1"
+
+		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return(localAddrs, true)
+
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "192.168.1.5:1111").Return(nil, fmt.Errorf("connection refused"))
+		fx.quic.MockTransport.EXPECT().Dial(gomock.Any(), "192.168.1.5:1112").Return(fx.mockMC(peerId), nil)
+
+		p, err := fx.Dial(ctx, peerId)
+		require.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+	t.Run("hostname resolving to local addr prefers yamux", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		fx.PreferQuic(true)
+		var peerId = "p1"
+
+		fx.setResolver(func(_ context.Context, host string) ([]net.IPAddr, error) {
+			require.Equal(t, "any-sync-node-1", host)
+			return []net.IPAddr{{IP: net.ParseIP("172.18.0.5")}}, nil
+		})
+		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return([]string{
+			"quic://any-sync-node-1:1112",
+			"yamux://any-sync-node-1:1111",
+		}, true)
+
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "any-sync-node-1:1111").Return(fx.mockMC(peerId), nil)
+
+		p, err := fx.Dial(ctx, peerId)
+		require.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+	t.Run("unresolved hostname keeps global order", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		fx.PreferQuic(true)
+		var peerId = "p1"
+
+		fx.setResolver(func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			return nil, fmt.Errorf("no such host")
+		})
+		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return([]string{
+			"yamux://example.org:1111",
+			"quic://example.org:1112",
+		}, true)
+
+		fx.quic.MockTransport.EXPECT().Dial(gomock.Any(), "example.org:1112").Return(fx.mockMC(peerId), nil)
+
+		p, err := fx.Dial(ctx, peerId)
+		require.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+	t.Run("hostname verdict is cached", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		fx.PreferQuic(true)
+		var peerId = "p1"
+		var resolveCalls int
+
+		fx.setResolver(func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			resolveCalls++
+			return []net.IPAddr{{IP: net.ParseIP("10.0.0.7")}}, nil
+		})
+		fx.nodeConf.EXPECT().PeerAddresses(peerId).Return([]string{"yamux://box.lan:1111"}, true).Times(2)
+		fx.yamux.MockTransport.EXPECT().Dial(gomock.Any(), "box.lan:1111").Return(fx.mockMC(peerId), nil).Times(2)
+
+		for i := 0; i < 2; i++ {
+			p, err := fx.Dial(ctx, peerId)
+			require.NoError(t, err)
+			assert.NotNil(t, p)
+		}
+		assert.Equal(t, 1, resolveCalls)
 	})
 }
 
@@ -136,7 +236,7 @@ func TestPeerService_DialWebTransport(t *testing.T) {
 		defer fx.finish(t)
 
 		ps := fx.PeerService.(*peerService)
-		schemes := ps.preferredSchemes()
+		schemes := ps.preferredSchemes(false)
 		assert.Contains(t, schemes, transport.WebTransport)
 	})
 	t.Run("fallback to webtransport when yamux fails", func(t *testing.T) {
@@ -199,6 +299,10 @@ func newFixture(t *testing.T) *fixture {
 
 	require.NoError(t, fx.a.Start(ctx))
 	return fx
+}
+
+func (fx *fixture) setResolver(resolve func(ctx context.Context, host string) ([]net.IPAddr, error)) {
+	fx.PeerService.(*peerService).localAddrs.resolve = resolve
 }
 
 func (fx *fixture) mockMC(peerId string) *mock_transport.MockMultiConn {


### PR DESCRIPTION
Refs anytype-heart GO-7424 / [PR #3233](https://github.com/anyproto/anytype-heart/pull/3233)

### Problems
- `Dial` orders schemes globally (`preferQuic`), so clients try every `quic://` address before any `yamux://` one. For private/LAN destinations a dead UDP port burns the whole QUIC handshake timeout (no ICMP feedback on the unconnected dial sockets), while TCP fails with an RST in one RTT. Hits self-hosted nodes on LAN IPs and docker-compose hostnames.
- `Dial` leaked the established connection (fd + session goroutines) when the peer id mismatched after the handshake.

### Changes
- Per-address scheme order: `preferredSchemes(preferQuic && !isLocal(addr))` over a flat, stably-sorted candidate list. Loopback/private/link-local destinations try yamux first; everything else keeps the global order.
- Hostnames are classified with a 200ms-bounded lookup and a cached verdict (locally answered names only — hosts file, docker embedded DNS, mDNS cache). A wrong verdict only affects ordering; every address is still dialed. Failed lookups cache for 5s; lookups canceled by the caller's dial budget are not cached.
- `Dial` closes the MultiConn on peer-id mismatch or peer construction failure.

### Compatibility
- Servers are byte-for-byte unchanged: with `preferQuic` unset the order is yamux-first either way and the local check is short-circuited away — pinned by a test that fails if the resolver ever runs with `preferQuic=false`.
- For all non-local inputs the dial sequence is identical to the old scheme-outer loop (bare addrs, unknown schemes, unregistered transports, duplicates included).