### PR TITLE
spacepayloads: any.onetoone 1-1 header type (SYN-131)

### DIFF
--- a/commonspace/spacepayloads/payloads.go
+++ b/commonspace/spacepayloads/payloads.go
@@ -57,7 +57,22 @@ type SpaceDerivePayload struct {
 
 const (
 	SpaceReserved = "any-sync.space"
+
+	// SpaceTypeOneToOne is the legacy 1-1 header type used by anytype
+	// clients. SpaceTypeOneToOneAny is the `any` product's variant; its
+	// headers carry fileproto v2. Both peers derive the 1-1 space id
+	// from the header, so the type selects which product's 1-1 space a
+	// pair of identities shares — the two variants derive distinct ids
+	// and never interoperate.
+	SpaceTypeOneToOne    = "anytype.onetoone"
+	SpaceTypeOneToOneAny = "any.onetoone"
 )
+
+// IsOneToOneType reports whether spaceType is one of the 1-1 header
+// types.
+func IsOneToOneType(spaceType string) bool {
+	return spaceType == SpaceTypeOneToOne || spaceType == SpaceTypeOneToOneAny
+}
 
 var ErrIncorrectIdentity = errors.New("incorrect identity")
 var ErrIncorrectOneToOnePayload = errors.New("incorrect onetoone payload")
@@ -437,7 +452,20 @@ func makeOneToOneInfo(sharedSk crypto.PrivKey, aPk, bPk crypto.PubKey) (oneToOne
 	return
 }
 
+// StoragePayloadForOneToOneSpace builds the legacy (anytype) 1-1 space
+// payload. See StoragePayloadForOneToOneSpaceWithType.
 func StoragePayloadForOneToOneSpace(aSk crypto.PrivKey, bPk crypto.PubKey) (storagePayload spacestorage.SpaceStorageCreatePayload, err error) {
+	return StoragePayloadForOneToOneSpaceWithType(aSk, bPk, SpaceTypeOneToOne)
+}
+
+// StoragePayloadForOneToOneSpaceWithType builds a 1-1 space payload
+// with the given header type (a IsOneToOneType value). The type is
+// content-addressed into the derived space id, so both peers must use
+// the same one.
+func StoragePayloadForOneToOneSpaceWithType(aSk crypto.PrivKey, bPk crypto.PubKey, spaceType string) (storagePayload spacestorage.SpaceStorageCreatePayload, err error) {
+	if !IsOneToOneType(spaceType) {
+		return storagePayload, fmt.Errorf("not a 1-1 space type: %q", spaceType)
+	}
 	sharedSk, err := crypto.GenerateSharedKey(aSk, bPk, crypto.AnysyncOneToOneSpacePath)
 	if err != nil {
 		return
@@ -497,12 +525,16 @@ func StoragePayloadForOneToOneSpace(aSk crypto.PrivKey, bPk crypto.PubKey) (stor
 	// preparing header and space id
 	header := &spacesyncproto.SpaceHeader{
 		Identity:           identity,
-		SpaceType:          "anytype.onetoone",
+		SpaceType:          spaceType,
 		SpaceHeaderPayload: oneToOneInfoBytes,
 		ReplicationKey:     repKey,
 		SettingPayload:     settingsRoot.RawChange,
 		Version:            spacesyncproto.SpaceHeaderVersion_SpaceHeaderVersion1,
 		AclPayload:         aclRoot.Payload,
+	}
+	if spaceType == SpaceTypeOneToOneAny {
+		// any.* headers are files-v2 only (coordinator-enforced).
+		header.FileprotoVersion = spacesyncproto.SpaceFileProtoVersion_SpaceFileProtoVersionV2
 	}
 	marshalled, err := header.MarshalVT()
 	if err != nil {
@@ -603,7 +635,7 @@ func ValidateSpaceHeader(rawHeaderWithId *spacesyncproto.RawSpaceHeaderWithId, i
 		}
 	}
 
-	if header.SpaceType == "anytype.onetoone" {
+	if IsOneToOneType(header.SpaceType) {
 		var oneToOneInfo aclrecordproto.AclOneToOneInfo
 		err = oneToOneInfo.UnmarshalVT(header.SpaceHeaderPayload)
 		if err != nil {

--- a/commonspace/spacepayloads/payloads_test.go
+++ b/commonspace/spacepayloads/payloads_test.go
@@ -547,6 +547,39 @@ func TestStoragePayloadForOneToOneSpace(t *testing.T) {
 		require.NoError(t, ValidateSpaceStorageCreatePayload(spB))
 	})
 
+	t.Run("any.onetoone variant: symmetric, validated, distinct id, fileproto v2", func(t *testing.T) {
+		aSk, aPk, _ := crypto.GenerateRandomEd25519KeyPair()
+		bSk, bPk, _ := crypto.GenerateRandomEd25519KeyPair()
+
+		spA, err := StoragePayloadForOneToOneSpaceWithType(aSk, bPk, SpaceTypeOneToOneAny)
+		require.NoError(t, err)
+		spB, err := StoragePayloadForOneToOneSpaceWithType(bSk, aPk, SpaceTypeOneToOneAny)
+		require.NoError(t, err)
+
+		assert.True(t, bytes.Equal(spA.SpaceHeaderWithId.RawHeader, spB.SpaceHeaderWithId.RawHeader))
+		require.NoError(t, ValidateSpaceStorageCreatePayload(spA))
+		require.NoError(t, ValidateSpaceStorageCreatePayload(spB))
+
+		legacy, err := StoragePayloadForOneToOneSpace(aSk, bPk)
+		require.NoError(t, err)
+		assert.NotEqual(t, legacy.SpaceHeaderWithId.Id, spA.SpaceHeaderWithId.Id,
+			"the two 1-1 variants must derive distinct space ids")
+
+		var raw spacesyncproto.RawSpaceHeader
+		require.NoError(t, raw.UnmarshalVT(spA.SpaceHeaderWithId.RawHeader))
+		var header spacesyncproto.SpaceHeader
+		require.NoError(t, header.UnmarshalVT(raw.SpaceHeader))
+		assert.Equal(t, SpaceTypeOneToOneAny, header.SpaceType)
+		assert.Equal(t, spacesyncproto.SpaceFileProtoVersion_SpaceFileProtoVersionV2, header.FileprotoVersion)
+	})
+
+	t.Run("non-1-1 type rejected", func(t *testing.T) {
+		aSk, _, _ := crypto.GenerateRandomEd25519KeyPair()
+		_, bPk, _ := crypto.GenerateRandomEd25519KeyPair()
+		_, err := StoragePayloadForOneToOneSpaceWithType(aSk, bPk, "anytype.space")
+		require.Error(t, err)
+	})
+
 }
 
 func rawSettingsPayload(accountKeys *accountdata.AccountKeys, spaceId, aclHeadId string) (rawIdChange *treechangeproto.RawTreeChangeWithId, err error) {


### PR DESCRIPTION
Adds the `any` product's 1-1 space type. 1-1 spaces pair only within a product (any↔any, anytype↔anytype), and the header type is content-addressed into the symmetric derived id — so distinct types make cross-product 1-1s structurally impossible and let infra tell the two apart.

- `StoragePayloadForOneToOneSpaceWithType(aSk, bPk, spaceType)` builds a 1-1 payload for either type; `any.onetoone` headers carry `fileprotoVersion=2` (the coordinator requires it for `any.*`). `StoragePayloadForOneToOneSpace` keeps the legacy anytype type — existing callers unchanged.
- `ValidateSpaceHeader` routes both types through the `AclOneToOneInfo` branch (`IsOneToOneType`); previously `any.onetoone` fell into the identity-equality branch and failed against the shared-key signer.
- Exported consts `SpaceTypeOneToOne` / `SpaceTypeOneToOneAny` replace the string literals.

Consumers: the coordinator/node need this for validation before any client ships the new type; the SDK threads the type through its 1-1 derive paths. Part of SYN-131 (anyproto/any-sync-coordinator#140, anyproto/any-sync-sdk#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)