### PR TITLE
ocache: refuse to close an entry that is still loading (GO-7333)

### DIFF
--- a/app/ocache/entry.go
+++ b/app/ocache/entry.go
@@ -11,7 +11,7 @@ import (
 type entryState int
 
 const (
-	entryStateLoading = iota
+	entryStateLoading entryState = iota
 	entryStateActive
 	entryStateClosing
 	entryStateClosed
@@ -79,20 +79,14 @@ func (e *entry) cancelLoad() {
 }
 
 func (e *entry) waitLoad(ctx context.Context, id string) (value Object, err error) {
-	// a completed load wins over a done ctx: Close passes a deadline that may
-	// already be spent for entries late in its pass, and those must still
-	// observe their loaded values
-	select {
-	case <-e.load:
-		return e.value, e.loadErr
-	default:
-	}
 	select {
 	case <-ctx.Done():
-		// both cases may have been ready and the select picks randomly:
-		// re-check so the completed-load rule is total, not best-effort.
-		// The window is a few instructions wide — no test can observe it;
-		// the guarantee is structural.
+		// a completed load wins over a done ctx: Close passes a deadline
+		// that may already be spent for entries late in its pass, and both
+		// cases may have been ready with the select picking randomly —
+		// re-check the load channel before failing. (The window is a few
+		// instructions wide; no test can observe it, the guarantee is
+		// structural.)
 		select {
 		case <-e.load:
 			return e.value, e.loadErr
@@ -154,7 +148,7 @@ func (e *entry) setClosing(ctx context.Context, wait bool) (prevState, curState 
 	// have already moved the entry back to closing (e.g. a busy GC/TryRemove
 	// reverted it to active and a concurrent remover re-acquired it). Re-check
 	// and wait on the new close channel instead of overwriting e.close, which
-	// would let two removers close the same channel twice (GO-7332).
+	// would let two removers close the same channel twice.
 	for e.state == entryStateClosing {
 		waitCh := e.close
 		e.mx.Unlock()
@@ -183,15 +177,17 @@ func (e *entry) setClosing(ctx context.Context, wait bool) (prevState, curState 
 func (e *entry) setActive(chClose bool) {
 	e.mx.Lock()
 	defer e.mx.Unlock()
+	// state before close: a close panic must not leave the entry in closing
+	// with an already-closed channel, which would spin waitClose callers
+	e.state = entryStateActive
 	if chClose {
 		close(e.close)
 	}
-	e.state = entryStateActive
 }
 
 func (e *entry) setClosed() {
 	e.mx.Lock()
 	defer e.mx.Unlock()
-	close(e.close)
 	e.state = entryStateClosed
+	close(e.close)
 }

--- a/app/ocache/entry.go
+++ b/app/ocache/entry.go
@@ -90,7 +90,9 @@ func (e *entry) waitLoad(ctx context.Context, id string) (value Object, err erro
 	select {
 	case <-ctx.Done():
 		// both cases may have been ready and the select picks randomly:
-		// re-check so the completed-load rule is total, not best-effort
+		// re-check so the completed-load rule is total, not best-effort.
+		// The window is a few instructions wide — no test can observe it;
+		// the guarantee is structural.
 		select {
 		case <-e.load:
 			return e.value, e.loadErr

--- a/app/ocache/entry.go
+++ b/app/ocache/entry.go
@@ -32,7 +32,10 @@ type entry struct {
 	value       Object
 	close       chan struct{}
 	mx          sync.Mutex
-	cancel      context.CancelFunc
+	// cancel aborts the load. Written once, before the entry is published
+	// into oCache.data under c.mu; every cross-goroutine reader reaches the
+	// entry through c.mu, which orders it after the write.
+	cancel context.CancelFunc
 }
 
 func newEntry(id string, value Object, state entryState) *entry {
@@ -43,6 +46,16 @@ func newEntry(id string, value Object, state entryState) *entry {
 		state:     state,
 		value:     value,
 	}
+}
+
+// newLoadingEntry returns a loading entry with its load cancel registered.
+// The cancel must exist before the entry becomes visible in the cache: a
+// concurrent Close cancels loads through the entries it can see, and one it
+// found without a cancel would run to completion uncancelled.
+func newLoadingEntry(id string, ctx context.Context) (e *entry, loadCtx context.Context) {
+	e = newEntry(id, nil, entryStateLoading)
+	loadCtx, e.cancel = context.WithCancel(ctx)
+	return
 }
 
 func (e *entry) isActive() bool {
@@ -76,6 +89,13 @@ func (e *entry) waitLoad(ctx context.Context, id string) (value Object, err erro
 	}
 	select {
 	case <-ctx.Done():
+		// both cases may have been ready and the select picks randomly:
+		// re-check so the completed-load rule is total, not best-effort
+		select {
+		case <-e.load:
+			return e.value, e.loadErr
+		default:
+		}
 		log.DebugCtx(ctx, "ctx done while waiting on object load", zap.String("id", id))
 		return nil, ctx.Err()
 	case <-e.load:

--- a/app/ocache/entry.go
+++ b/app/ocache/entry.go
@@ -57,12 +57,6 @@ func (e *entry) isClosing() bool {
 	return e.state == entryStateClosed || e.state == entryStateClosing
 }
 
-func (e *entry) setCancel(cancel context.CancelFunc) {
-	e.mx.Lock()
-	defer e.mx.Unlock()
-	e.cancel = cancel
-}
-
 func (e *entry) cancelLoad() {
 	e.mx.Lock()
 	defer e.mx.Unlock()
@@ -72,6 +66,14 @@ func (e *entry) cancelLoad() {
 }
 
 func (e *entry) waitLoad(ctx context.Context, id string) (value Object, err error) {
+	// a completed load wins over a done ctx: Close passes a deadline that may
+	// already be spent for entries late in its pass, and those must still
+	// observe their loaded values
+	select {
+	case <-e.load:
+		return e.value, e.loadErr
+	default:
+	}
 	select {
 	case <-ctx.Done():
 		log.DebugCtx(ctx, "ctx done while waiting on object load", zap.String("id", id))
@@ -105,22 +107,23 @@ func (e *entry) waitClose(ctx context.Context, id string) (res bool, err error) 
 
 // setClosing transitions the entry to closing. With wait it blocks until another
 // closer is done with it, bounded by ctx: that closer may be inside a TryClose
-// that waits on an unresponsive peer. The transition happens only from the
-// active state; prevState tells the caller whether this call acquired it.
+// that waits on an unresponsive peer. Acquisition is mode-dependent: without
+// wait this call acquired the transition iff prevState == entryStateActive;
+// with wait it may acquire the transition after waiting out another closer
+// (prevState == entryStateClosing), so waiting callers must key on
+// curState == entryStateClosing instead.
 func (e *entry) setClosing(ctx context.Context, wait bool) (prevState, curState entryState, err error) {
 	e.mx.Lock()
 	prevState = e.state
 	curState = e.state
-	// A loading entry is not closeable: e.value is nil until oCache.load
-	// publishes it, and e.load is closed by that load alone. Marking it closing
-	// would hand the caller a nil value to close and would park the entry in
-	// closing behind a close channel nobody ever closes - the load's success
-	// path calls setActive(false) - stranding every later waitClose/waitLoad
-	// (GO-7333). Refuse rather than transition: undoing the transition
-	// afterwards is not equivalent, it either leaves the entry closing or makes
-	// it active with a nil value. Callers that must close a loading entry
-	// (Remove, RemoveSame, Close) wait the load out in oCache.removeCtx first,
-	// so they never arrive here in this state.
+	// A loading entry is refused: e.value is nil until oCache.load publishes
+	// it, and e.load is closed by that load alone. Marking it closing would
+	// hand the caller a nil value to close and would park any concurrent
+	// waitClose waiter behind a close channel the load never closes (its
+	// success path calls setActive(false)). Undoing the transition afterwards
+	// is not equivalent: it either leaves the entry closing or makes it active
+	// with a nil value. Callers that must close a loading entry (Remove,
+	// RemoveSame, Close) wait the load out in oCache.removeCtx first.
 	if e.state == entryStateLoading {
 		e.mx.Unlock()
 		return

--- a/app/ocache/entry.go
+++ b/app/ocache/entry.go
@@ -105,11 +105,26 @@ func (e *entry) waitClose(ctx context.Context, id string) (res bool, err error) 
 
 // setClosing transitions the entry to closing. With wait it blocks until another
 // closer is done with it, bounded by ctx: that closer may be inside a TryClose
-// that waits on an unresponsive peer.
+// that waits on an unresponsive peer. The transition happens only from the
+// active state; prevState tells the caller whether this call acquired it.
 func (e *entry) setClosing(ctx context.Context, wait bool) (prevState, curState entryState, err error) {
 	e.mx.Lock()
 	prevState = e.state
 	curState = e.state
+	// A loading entry is not closeable: e.value is nil until oCache.load
+	// publishes it, and e.load is closed by that load alone. Marking it closing
+	// would hand the caller a nil value to close and would park the entry in
+	// closing behind a close channel nobody ever closes - the load's success
+	// path calls setActive(false) - stranding every later waitClose/waitLoad
+	// (GO-7333). Refuse rather than transition: undoing the transition
+	// afterwards is not equivalent, it either leaves the entry closing or makes
+	// it active with a nil value. Callers that must close a loading entry
+	// (Remove, RemoveSame, Close) wait the load out in oCache.removeCtx first,
+	// so they never arrive here in this state.
+	if e.state == entryStateLoading {
+		e.mx.Unlock()
+		return
+	}
 	// Loop rather than `if`: after waking from <-waitCh another goroutine may
 	// have already moved the entry back to closing (e.g. a busy GC/TryRemove
 	// reverted it to active and a concurrent remover re-acquired it). Re-check

--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -18,6 +19,23 @@ var (
 	ErrNotExists = errors.New("object not exists")
 	ErrNilValue  = errors.New("nil value")
 )
+
+// errLoadPanic marks an entry whose loadFunc panicked instead of returning.
+var errLoadPanic = errors.New("load did not complete")
+
+// isNilObject reports whether value is nil or a typed-nil pointer wrapped in
+// the interface — calling methods on either panics in the close paths.
+func isNilObject(value Object) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	}
+	return false
+}
 
 var (
 	defaultTTL = time.Minute
@@ -50,8 +68,9 @@ var WithGCPeriod = func(gcPeriod time.Duration) Option {
 	}
 }
 
-// WithCloseTimeout bounds Close's whole pass (default 10s); consumers holding
-// several caches can budget their total shutdown with it.
+// WithCloseTimeout bounds Close's waits on in-flight loads and on entries
+// another closer holds (default 10s). The value.Close calls themselves take
+// no ctx and are not bounded.
 var WithCloseTimeout = func(d time.Duration) Option {
 	return func(cache *oCache) {
 		cache.closeTimeout = d
@@ -91,11 +110,16 @@ type OCache interface {
 	// under a global lock, this will prevent a race which otherwise occurs
 	// when object is created in parallel with action
 	DoLockedIfNotExists(id string, action func() error) error
-	// Get gets an object from cache or creates a new one via 'loadFunc'
+	// Get gets an object from cache or creates a new one via 'loadFunc';
+	// it also refreshes the object's GC deadline.
 	// When 'loadFunc' returns a non-nil error, an object will not be stored to cache.
 	// A load that completed by the time ctx is done still returns its value.
+	// Returns ErrClosed on a closed cache, including for waiters whose load
+	// lands after Close.
 	Get(ctx context.Context, id string) (value Object, err error)
-	// Pick returns value if it's presents in cache (will not call loadFunc)
+	// Pick returns value if it's present in cache (will not call loadFunc,
+	// does not refresh the GC deadline) — but it waits out an in-flight load
+	// for the id, bounded by ctx. Returns ErrClosed on a closed cache.
 	Pick(ctx context.Context, id string) (value Object, err error)
 	// Add adds new object to cache
 	// Returns error when the value is nil, the object exists or the cache is closed
@@ -121,8 +145,9 @@ type OCache interface {
 	// Len returns current cache size
 	Len() int
 	// Close closes all objects and the cache. The pass is bounded by a close
-	// timeout; a load that outruns it is not waited for — its value is closed
-	// by the load itself when it completes.
+	// timeout; an entry held past it by an in-flight load or a busy closer is
+	// not waited for — its value is closed by that path's own closed-cache
+	// branch when it completes.
 	Close() (err error)
 }
 
@@ -208,6 +233,10 @@ func (c *oCache) Get(ctx context.Context, id string) (value Object, err error) {
 
 func (c *oCache) Pick(ctx context.Context, id string) (value Object, err error) {
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, ErrClosed
+	}
 	val, ok := c.data[id]
 	if !ok || val.isClosing() {
 		c.mu.Unlock()
@@ -220,7 +249,19 @@ func (c *oCache) Pick(ctx context.Context, id string) (value Object, err error) 
 
 // ctx is the cancellable load context Get created together with the entry.
 func (c *oCache) load(ctx context.Context, id string, e *entry) {
-	defer close(e.load)
+	defer func() {
+		// a panicking loadFunc arrives here with no result recorded; mark the
+		// entry failed and drop it before releasing waiters, or the id wedges
+		// forever with Get/Pick returning (nil, nil). The panic propagates to
+		// the loading caller.
+		if e.value == nil && e.loadErr == nil {
+			c.mu.Lock()
+			e.loadErr = errLoadPanic
+			delete(c.data, id)
+			c.mu.Unlock()
+		}
+		close(e.load)
+	}()
 	value, err := c.loadFunc(ctx, id)
 	// Read before cancelLoad(): a done ctx here means the load was killed
 	// (first caller gone, or cancelLoad on cache close) rather than the
@@ -229,8 +270,8 @@ func (c *oCache) load(ctx context.Context, id string, e *entry) {
 	e.cancelLoad()
 
 	c.mu.Lock()
-	if value == nil && err == nil {
-		err = fmt.Errorf("loaded value is nil, id: %s", id)
+	if isNilObject(value) && err == nil {
+		err = fmt.Errorf("loaded %w, id: %s", ErrNilValue, id)
 	}
 	if err != nil {
 		e.loadErr = err
@@ -365,6 +406,22 @@ func (c *oCache) tryCloseEntry(e *entry) (closed bool, err error) {
 	}
 	closed, err = e.value.TryClose(c.ttl)
 	if !closed {
+		c.mu.Lock()
+		cacheClosed := c.closed
+		c.mu.Unlock()
+		if cacheClosed {
+			// Close's pass may already have given up waiting on this entry:
+			// restoring it to active would resurrect a live value into a
+			// closed cache with no remaining closer. Escalate the decline
+			// instead — the mirror of load's closed-cache branch. If Close is
+			// still parked on e.close, setClosed wakes it into a safe refusal.
+			cErr := e.value.Close()
+			if err == nil {
+				err = cErr
+			}
+			c.closeAndDelete(e)
+			return true, err
+		}
 		e.setActive(true)
 		return false, err
 	}
@@ -387,7 +444,7 @@ func (c *oCache) DoLockedIfNotExists(id string, action func() error) error {
 func (c *oCache) Add(id string, value Object) (err error) {
 	// a nil value would panic every close path; the GC one runs on the
 	// unrecovered ticker goroutine and would take the process down
-	if value == nil {
+	if isNilObject(value) {
 		return ErrNilValue
 	}
 	c.mu.Lock()
@@ -407,6 +464,10 @@ func (c *oCache) Add(id string, value Object) (err error) {
 func (c *oCache) ForEach(f func(obj Object) (isContinue bool)) {
 	var objects []Object
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
 	for _, v := range c.data {
 		select {
 		case <-v.load:
@@ -497,7 +558,11 @@ func (c *oCache) Close() (err error) {
 	closingCtx, cancel := context.WithTimeout(context.Background(), c.closeTimeout)
 	defer cancel()
 	for _, e := range toClose {
-		if _, err := c.removeCtx(closingCtx, closingCtx, e); err != nil && err != ErrNotExists && err != ErrClosed {
+		// ErrClosed means c.load already handled the entry; context.Canceled
+		// is the loadErr of a load this Close killed itself — neither is
+		// worth a warning
+		if _, err := c.removeCtx(closingCtx, closingCtx, e); err != nil &&
+			!errors.Is(err, ErrNotExists) && !errors.Is(err, ErrClosed) && !errors.Is(err, context.Canceled) {
 			c.log.With("object_id", e.id).Warnf("cache close: object close error: %v", err)
 		}
 	}

--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -89,7 +89,7 @@ type OCache interface {
 	// Pick returns value if it's presents in cache (will not call loadFunc)
 	Pick(ctx context.Context, id string) (value Object, err error)
 	// Add adds new object to cache
-	// Returns error when object exists
+	// Returns error when object exists or the cache is closed
 	Add(id string, value Object) (err error)
 	// Remove closes and removes object
 	Remove(ctx context.Context, id string) (ok bool, err error)
@@ -146,9 +146,14 @@ func (c *oCache) Get(ctx context.Context, id string) (value Object, err error) {
 		}
 		e, ok := c.data[id]
 		load := false
+		var loadCtx context.Context
 		if !ok {
 			e = newEntry(id, nil, entryStateLoading)
 			load = true
+			// register the cancel before the entry becomes visible, so a
+			// concurrent Close cannot observe the entry with no cancel yet
+			// and miss the load
+			loadCtx, e.cancel = context.WithCancel(ctx)
 			c.data[id] = e
 		}
 		e.lastUsage = time.Now()
@@ -165,7 +170,7 @@ func (c *oCache) Get(ctx context.Context, id string) (value Object, err error) {
 			counted = true
 		}
 		if load {
-			c.load(ctx, id, e)
+			c.load(loadCtx, id, e)
 			value, err = e.value, e.loadErr
 		} else {
 			value, err = e.waitLoad(ctx, id)
@@ -203,16 +208,15 @@ func (c *oCache) Pick(ctx context.Context, id string) (value Object, err error) 
 	return val.waitLoad(ctx, id)
 }
 
+// ctx is the cancellable load context Get created together with the entry.
 func (c *oCache) load(ctx context.Context, id string, e *entry) {
 	defer close(e.load)
-	ctx, cancel := context.WithCancel(ctx)
-	e.setCancel(cancel)
 	value, err := c.loadFunc(ctx, id)
-	// Read before cancel(): a done ctx here means the load was killed
+	// Read before cancelLoad(): a done ctx here means the load was killed
 	// (first caller gone, or cancelLoad on cache close) rather than the
 	// loadFunc failing on its own — recorded so Get's waiters can retry.
 	aborted := ctx.Err() != nil
-	cancel()
+	e.cancelLoad()
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -285,11 +289,13 @@ func (c *oCache) RemoveSame(ctx context.Context, id string, value Object) (ok bo
 	}
 	e, exists := c.data[id]
 	// e.value is written only under c.mu (in Add/load), so reading it here is
-	// race-free. remove() acts on this exact entry: it deletes/closes it only
+	// race-free. A nil value never matches: a mid-load entry's value is still
+	// nil, and matching it would wait the load out and close whatever object
+	// it publishes. remove() acts on this exact entry: it deletes/closes it only
 	// if this call is the one that transitions it to closing. If e was already
 	// replaced under the same id it is in a closed state and remove() is a
 	// no-op, so a stale caller can never close the newer value that took the id.
-	same := exists && e.value == value
+	same := exists && value != nil && e.value == value
 	c.mu.Unlock()
 	if !same {
 		return false, ErrNotExists
@@ -313,27 +319,32 @@ func (c *oCache) TryRemove(id string) (ok bool, err error) {
 
 	c.mu.Unlock()
 
-	// Only prevState == entryStateActive means this call acquired the closing
-	// transition and may touch e.value; loading refuses it, closing/closed
-	// belong to another closer.
+	ok, err = c.tryCloseEntry(e)
+	if err != nil {
+		c.log.With("object_id", e.id).Warnf("try remove err: %v", err)
+	}
+	return ok, err
+}
+
+// tryCloseEntry acquires the closing transition and asks the value whether it
+// can close. Only prevState == entryStateActive means this call acquired the
+// transition and may touch e.value; loading refuses it, closing/closed belong
+// to another closer. A value that declined or errored is restored to active —
+// abandoning an acquired transition would park the entry in closing behind a
+// close channel nobody ever closes, wedging the id. A closed value is
+// finalized even when TryClose also returned an error.
+func (c *oCache) tryCloseEntry(e *entry) (closed bool, err error) {
 	prevState, _, _ := e.setClosing(context.Background(), false)
 	if prevState != entryStateActive {
 		return false, nil
 	}
-
-	closed, err := e.value.TryClose(c.ttl)
-	if err != nil {
-		c.log.With("object_id", e.id).Warnf("try remove err: %v", err)
-		return closed, err
-	}
-
+	closed, err = e.value.TryClose(c.ttl)
 	if !closed {
 		e.setActive(true)
-		return false, nil
+		return false, err
 	}
-
 	c.closeAndDelete(e)
-	return true, nil
+	return true, err
 }
 
 func (c *oCache) DoLockedIfNotExists(id string, action func() error) error {
@@ -351,6 +362,9 @@ func (c *oCache) DoLockedIfNotExists(id string, action func() error) error {
 func (c *oCache) Add(id string, value Object) (err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.closed {
+		return ErrClosed
+	}
 	if _, ok := c.data[id]; ok {
 		return ErrExists
 	}
@@ -410,20 +424,12 @@ func (c *oCache) GC() {
 	c.mu.Unlock()
 	closedNum := 0
 	for _, e := range toClose {
-		prevState, _, _ := e.setClosing(context.Background(), false)
-		if prevState != entryStateActive {
-			continue
-		}
-		closed, err := e.value.TryClose(c.ttl)
+		closed, err := c.tryCloseEntry(e)
 		if err != nil {
 			c.log.With("object_id", e.id).Warnf("GC: object close error: %v", err)
 		}
-		if !closed {
-			e.setActive(true)
-			continue
-		} else {
+		if closed {
 			closedNum++
-			c.closeAndDelete(e)
 		}
 	}
 	c.metricsClosed(closedNum, size)
@@ -449,14 +455,16 @@ func (c *oCache) Close() (err error) {
 		toClose = append(toClose, e)
 	}
 	c.mu.Unlock()
-	// one deadline for the whole pass, spent only on entries another closer holds:
-	// that closer can be a gc stuck in TryClose on an unresponsive peer. Loads are
-	// already cancelled above, and value.Close takes no ctx, so uncontended entries
-	// still close normally once the deadline has passed.
+	// one deadline for the whole pass, spent only on entries another closer or
+	// an unresponsive load holds: that closer can be a gc stuck in TryClose on
+	// an unresponsive peer, and a loadFunc that ignores its cancelled ctx must
+	// forfeit its entry rather than wedge Close. Completed loads win over the
+	// spent deadline inside waitLoad, and value.Close takes no ctx, so
+	// uncontended entries still close normally once the deadline has passed.
 	closingCtx, cancel := context.WithTimeout(context.Background(), c.closeTimeout)
 	defer cancel()
 	for _, e := range toClose {
-		if _, err := c.removeCtx(context.Background(), closingCtx, e); err != nil && err != ErrNotExists {
+		if _, err := c.removeCtx(closingCtx, closingCtx, e); err != nil && err != ErrNotExists {
 			c.log.With("object_id", e.id).Warnf("cache close: object close error: %v", err)
 		}
 	}

--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -20,8 +20,10 @@ var (
 	ErrNilValue  = errors.New("nil value")
 )
 
-// errLoadPanic marks an entry whose loadFunc panicked instead of returning.
-var errLoadPanic = errors.New("load did not complete")
+// ErrLoadPanic is what every waiter on a load receives when the loadFunc
+// panicked instead of returning; the panic itself propagates to the loading
+// caller.
+var ErrLoadPanic = errors.New("loadFunc panicked")
 
 // isNilObject reports whether value is nil or a typed-nil pointer wrapped in
 // the interface — calling methods on either panics in the close paths.
@@ -73,7 +75,9 @@ var WithGCPeriod = func(gcPeriod time.Duration) Option {
 // no ctx and are not bounded.
 var WithCloseTimeout = func(d time.Duration) Option {
 	return func(cache *oCache) {
-		cache.closeTimeout = d
+		if d > 0 {
+			cache.closeTimeout = d
+		}
 	}
 }
 
@@ -256,9 +260,10 @@ func (c *oCache) load(ctx context.Context, id string, e *entry) {
 		// the loading caller.
 		if e.value == nil && e.loadErr == nil {
 			c.mu.Lock()
-			e.loadErr = errLoadPanic
+			e.loadErr = ErrLoadPanic
 			delete(c.data, id)
 			c.mu.Unlock()
+			e.cancelLoad() // release the load ctx the normal exits cancel
 		}
 		close(e.load)
 	}()
@@ -312,30 +317,28 @@ func (c *oCache) Remove(ctx context.Context, id string) (ok bool, err error) {
 		return false, ErrNotExists
 	}
 	c.mu.Unlock()
-	return c.remove(ctx, e)
+	return c.removeCtx(ctx, e)
 }
 
 // closeAndDelete finalizes a closing entry under c.mu. The deferred unlock
-// guarantees c.mu is released even if setClosed panics, so a panic in the
-// close path can never leave the whole cache wedged (GO-7332 hardening).
+// keeps c.mu released even if setClosed panics, and deleting first means a
+// panicking setClosed cannot leave a closed-state entry in the map for Get
+// to reload against forever.
 func (c *oCache) closeAndDelete(e *entry) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	e.setClosed()
 	delete(c.data, e.id)
+	e.setClosed()
 }
 
-func (c *oCache) remove(ctx context.Context, e *entry) (ok bool, err error) {
-	return c.removeCtx(ctx, ctx, e)
-}
-
-// loadCtx bounds waiting for an in-flight load, closingCtx bounds waiting for
-// another closer to release the entry
-func (c *oCache) removeCtx(loadCtx, closingCtx context.Context, e *entry) (ok bool, err error) {
-	if _, err = e.waitLoad(loadCtx, e.id); err != nil {
+// removeCtx waits out an in-flight load and any other closer (both bounded by
+// ctx), then closes and deletes the entry if this call acquired the closing
+// transition.
+func (c *oCache) removeCtx(ctx context.Context, e *entry) (ok bool, err error) {
+	if _, err = e.waitLoad(ctx, e.id); err != nil {
 		return false, err
 	}
-	_, curState, err := e.setClosing(closingCtx, true)
+	_, curState, err := e.setClosing(ctx, true)
 	if err != nil {
 		return false, err
 	}
@@ -366,7 +369,7 @@ func (c *oCache) RemoveSame(ctx context.Context, id string, value Object) (ok bo
 	if !same {
 		return false, ErrNotExists
 	}
-	return c.remove(ctx, e)
+	return c.removeCtx(ctx, e)
 }
 
 func (c *oCache) TryRemove(id string) (ok bool, err error) {
@@ -407,23 +410,26 @@ func (c *oCache) tryCloseEntry(e *entry) (closed bool, err error) {
 	closed, err = e.value.TryClose(c.ttl)
 	if !closed {
 		c.mu.Lock()
-		cacheClosed := c.closed
-		c.mu.Unlock()
-		if cacheClosed {
-			// Close's pass may already have given up waiting on this entry:
-			// restoring it to active would resurrect a live value into a
-			// closed cache with no remaining closer. Escalate the decline
-			// instead — the mirror of load's closed-cache branch. If Close is
-			// still parked on e.close, setClosed wakes it into a safe refusal.
-			cErr := e.value.Close()
-			if err == nil {
-				err = cErr
-			}
-			c.closeAndDelete(e)
-			return true, err
+		if !c.closed {
+			// the restore happens under the same c.mu hold that read
+			// c.closed: Close's set-closed-and-snapshot section then runs
+			// either before this check (the escalation below is taken) or
+			// after the restore (the snapshot holds the entry and Close's
+			// pass closes it) — never between, where the restored value
+			// would leak
+			e.setActive(true)
+			c.mu.Unlock()
+			return false, err
 		}
-		e.setActive(true)
-		return false, err
+		c.mu.Unlock()
+		// Close's pass may already have given up waiting on this entry:
+		// restoring it to active would resurrect a live value into a closed
+		// cache with no remaining closer. Escalate the decline instead — the
+		// mirror of load's closed-cache branch. If Close is still parked on
+		// e.close, setClosed wakes it into a safe refusal.
+		err = errors.Join(err, e.value.Close())
+		c.closeAndDelete(e)
+		return true, err
 	}
 	c.closeAndDelete(e)
 	return true, err
@@ -558,10 +564,11 @@ func (c *oCache) Close() (err error) {
 	closingCtx, cancel := context.WithTimeout(context.Background(), c.closeTimeout)
 	defer cancel()
 	for _, e := range toClose {
-		// ErrClosed means c.load already handled the entry; context.Canceled
-		// is the loadErr of a load this Close killed itself — neither is
-		// worth a warning
-		if _, err := c.removeCtx(closingCtx, closingCtx, e); err != nil &&
+		// ErrClosed means c.load already handled the entry, context.Canceled
+		// is the loadErr of a load this Close killed itself, and ErrNotExists
+		// is a loadFunc verdict (a load that found nothing left nothing to
+		// close) — none are worth a warning
+		if _, err := c.removeCtx(closingCtx, e); err != nil &&
 			!errors.Is(err, ErrNotExists) && !errors.Is(err, ErrClosed) && !errors.Is(err, context.Canceled) {
 			c.log.With("object_id", e.id).Warnf("cache close: object close error: %v", err)
 		}

--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -313,8 +313,11 @@ func (c *oCache) TryRemove(id string) (ok bool, err error) {
 
 	c.mu.Unlock()
 
+	// Only prevState == entryStateActive means this call acquired the closing
+	// transition and may touch e.value; loading refuses it, closing/closed
+	// belong to another closer.
 	prevState, _, _ := e.setClosing(context.Background(), false)
-	if prevState == entryStateClosing || prevState == entryStateClosed {
+	if prevState != entryStateActive {
 		return false, nil
 	}
 
@@ -408,7 +411,7 @@ func (c *oCache) GC() {
 	closedNum := 0
 	for _, e := range toClose {
 		prevState, _, _ := e.setClosing(context.Background(), false)
-		if prevState == entryStateClosing || prevState == entryStateClosed {
+		if prevState != entryStateActive {
 			continue
 		}
 		closed, err := e.value.TryClose(c.ttl)

--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -16,6 +16,7 @@ var (
 	ErrClosed    = errors.New("object cache closed")
 	ErrExists    = errors.New("object exists")
 	ErrNotExists = errors.New("object not exists")
+	ErrNilValue  = errors.New("nil value")
 )
 
 var (
@@ -46,6 +47,14 @@ var WithTTL = func(ttl time.Duration) Option {
 var WithGCPeriod = func(gcPeriod time.Duration) Option {
 	return func(cache *oCache) {
 		cache.gc = gcPeriod
+	}
+}
+
+// WithCloseTimeout bounds Close's whole pass (default 10s); consumers holding
+// several caches can budget their total shutdown with it.
+var WithCloseTimeout = func(d time.Duration) Option {
+	return func(cache *oCache) {
+		cache.closeTimeout = d
 	}
 }
 
@@ -82,14 +91,14 @@ type OCache interface {
 	// under a global lock, this will prevent a race which otherwise occurs
 	// when object is created in parallel with action
 	DoLockedIfNotExists(id string, action func() error) error
-	// Get gets an object from cache or create a new one via 'loadFunc'
-	// Increases the object refs counter on successful
-	// When 'loadFunc' returns a non-nil error, an object will not be stored to cache
+	// Get gets an object from cache or creates a new one via 'loadFunc'
+	// When 'loadFunc' returns a non-nil error, an object will not be stored to cache.
+	// A load that completed by the time ctx is done still returns its value.
 	Get(ctx context.Context, id string) (value Object, err error)
 	// Pick returns value if it's presents in cache (will not call loadFunc)
 	Pick(ctx context.Context, id string) (value Object, err error)
 	// Add adds new object to cache
-	// Returns error when object exists or the cache is closed
+	// Returns error when the value is nil, the object exists or the cache is closed
 	Add(id string, value Object) (err error)
 	// Remove closes and removes object
 	Remove(ctx context.Context, id string) (ok bool, err error)
@@ -99,7 +108,10 @@ type OCache interface {
 	// that has replaced it under the same id. Returns ok=true only when this
 	// call performed the removal.
 	RemoveSame(ctx context.Context, id string, value Object) (ok bool, err error)
-	// TryRemove Tries to close and to remove the object
+	// TryRemove tries to close and to remove the object. ok reports whether
+	// this call removed it; (false, nil) means the object declined to close,
+	// is still loading, or another closer owns it. A non-nil err can
+	// accompany ok=true when the value closed with an error.
 	TryRemove(id string) (ok bool, err error)
 	// ForEach iterates over all loaded objects, breaks when callback returns false
 	ForEach(f func(v Object) (isContinue bool))
@@ -108,7 +120,9 @@ type OCache interface {
 	GC()
 	// Len returns current cache size
 	Len() int
-	// Close closes all objects and cache
+	// Close closes all objects and the cache. The pass is bounded by a close
+	// timeout; a load that outruns it is not waited for — its value is closed
+	// by the load itself when it completes.
 	Close() (err error)
 }
 
@@ -148,12 +162,8 @@ func (c *oCache) Get(ctx context.Context, id string) (value Object, err error) {
 		load := false
 		var loadCtx context.Context
 		if !ok {
-			e = newEntry(id, nil, entryStateLoading)
+			e, loadCtx = newLoadingEntry(id, ctx)
 			load = true
-			// register the cancel before the entry becomes visible, so a
-			// concurrent Close cannot observe the entry with no cancel yet
-			// and miss the load
-			loadCtx, e.cancel = context.WithCancel(ctx)
 			c.data[id] = e
 		}
 		e.lastUsage = time.Now()
@@ -219,7 +229,6 @@ func (c *oCache) load(ctx context.Context, id string, e *entry) {
 	e.cancelLoad()
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if value == nil && err == nil {
 		err = fmt.Errorf("loaded value is nil, id: %s", id)
 	}
@@ -227,10 +236,26 @@ func (c *oCache) load(ctx context.Context, id string, e *entry) {
 		e.loadErr = err
 		e.loadAborted = aborted
 		delete(c.data, id)
-	} else {
-		e.value = value
-		e.setActive(false)
+		c.mu.Unlock()
+		return
 	}
+	if c.closed {
+		// Close has already run (and possibly given up waiting on this load):
+		// republishing the value into a closed cache would leak it, since no
+		// path closes entries after Close. Close it here instead; waiters get
+		// ErrClosed. The deferred close(e.load) fires after value.Close(), so
+		// anyone woken by it observes the value already closed.
+		e.loadErr = ErrClosed
+		delete(c.data, id)
+		c.mu.Unlock()
+		if cErr := value.Close(); cErr != nil {
+			c.log.With("object_id", id).Warnf("load after close: value close error: %v", cErr)
+		}
+		return
+	}
+	e.value = value
+	e.setActive(false)
+	c.mu.Unlock()
 }
 
 func (c *oCache) Remove(ctx context.Context, id string) (ok bool, err error) {
@@ -360,6 +385,11 @@ func (c *oCache) DoLockedIfNotExists(id string, action func() error) error {
 }
 
 func (c *oCache) Add(id string, value Object) (err error) {
+	// a nil value would panic every close path; the GC one runs on the
+	// unrecovered ticker goroutine and would take the process down
+	if value == nil {
+		return ErrNilValue
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed {
@@ -458,13 +488,16 @@ func (c *oCache) Close() (err error) {
 	// one deadline for the whole pass, spent only on entries another closer or
 	// an unresponsive load holds: that closer can be a gc stuck in TryClose on
 	// an unresponsive peer, and a loadFunc that ignores its cancelled ctx must
-	// forfeit its entry rather than wedge Close. Completed loads win over the
-	// spent deadline inside waitLoad, and value.Close takes no ctx, so
-	// uncontended entries still close normally once the deadline has passed.
+	// forfeit its entry rather than wedge Close — its value is closed by
+	// c.load itself when it finally completes (the c.closed branch there).
+	// Completed loads win over the spent deadline inside waitLoad, and
+	// value.Close takes no ctx, so uncontended entries still close normally
+	// once the deadline has passed. ErrClosed from waitLoad means c.load
+	// already handled the entry, so it is not worth a warning.
 	closingCtx, cancel := context.WithTimeout(context.Background(), c.closeTimeout)
 	defer cancel()
 	for _, e := range toClose {
-		if _, err := c.removeCtx(closingCtx, closingCtx, e); err != nil && err != ErrNotExists {
+		if _, err := c.removeCtx(closingCtx, closingCtx, e); err != nil && err != ErrNotExists && err != ErrClosed {
 			c.log.With("object_id", e.id).Warnf("cache close: object close error: %v", err)
 		}
 	}

--- a/app/ocache/ocache.go
+++ b/app/ocache/ocache.go
@@ -72,7 +72,7 @@ var WithGCPeriod = func(gcPeriod time.Duration) Option {
 
 // WithCloseTimeout bounds Close's waits on in-flight loads and on entries
 // another closer holds (default 10s). The value.Close calls themselves take
-// no ctx and are not bounded.
+// no ctx and are not bounded. Non-positive values are ignored.
 var WithCloseTimeout = func(d time.Duration) Option {
 	return func(cache *oCache) {
 		if d > 0 {
@@ -409,19 +409,24 @@ func (c *oCache) tryCloseEntry(e *entry) (closed bool, err error) {
 	}
 	closed, err = e.value.TryClose(c.ttl)
 	if !closed {
-		c.mu.Lock()
-		if !c.closed {
-			// the restore happens under the same c.mu hold that read
+		restored := func() bool {
+			// the restore happens under the same c.mu hold that reads
 			// c.closed: Close's set-closed-and-snapshot section then runs
 			// either before this check (the escalation below is taken) or
 			// after the restore (the snapshot holds the entry and Close's
 			// pass closes it) — never between, where the restored value
 			// would leak
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if c.closed {
+				return false
+			}
 			e.setActive(true)
-			c.mu.Unlock()
+			return true
+		}()
+		if restored {
 			return false, err
 		}
-		c.mu.Unlock()
 		// Close's pass may already have given up waiting on this entry:
 		// restoring it to active would resurrect a live value into a closed
 		// cache with no remaining closer. Escalate the decline instead — the

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -282,11 +283,13 @@ func TestOCache_GC(t *testing.T) {
 		time.Sleep(time.Millisecond * 20)
 		var events []string
 		go func() {
+			// defer + assert (not require): a failed assertion must still
+			// close getCh, or the subtest deadlocks instead of failing
+			defer close(getCh)
 			_, err := c.Get(context.TODO(), "id")
-			require.NoError(t, err)
-			require.NotNil(t, val)
+			assert.NoError(t, err)
+			assert.NotNil(t, val)
 			events = append(events, "get")
-			close(getCh)
 		}()
 		// sleeping to make sure that Get is called
 		time.Sleep(time.Millisecond * 20)
@@ -391,19 +394,23 @@ func Test_OCache_Remove(t *testing.T) {
 		require.NotNil(t, val)
 		assert.Equal(t, 1, c.Len())
 		// removing the object, so we will wait on closing
+		removeDone := make(chan struct{})
 		go func() {
+			defer close(removeDone)
 			_, err := c.Remove(ctx, "id")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		time.Sleep(time.Millisecond * 20)
 
 		var events []string
 		go func() {
+			// defer + assert (not require): a failed assertion must still
+			// close getCh, or the subtest deadlocks instead of failing
+			defer close(getCh)
 			_, err := c.Get(context.TODO(), "id")
-			require.NoError(t, err)
-			require.NotNil(t, val)
+			assert.NoError(t, err)
+			assert.NotNil(t, val)
 			events = append(events, "get")
-			close(getCh)
 		}()
 		// sleeping to make sure that Get is called
 		time.Sleep(time.Millisecond * 20)
@@ -411,6 +418,7 @@ func Test_OCache_Remove(t *testing.T) {
 		close(closeCh)
 
 		<-getCh
+		<-removeDone
 		require.Equal(t, []string{"close", "get"}, events)
 	})
 	t.Run("tryRemove simple", func(t *testing.T) {
@@ -438,12 +446,12 @@ func Test_OCache_Remove(t *testing.T) {
 
 		var events []string
 		go func() {
+			defer close(getCh)
 			_, err := c.Get(context.TODO(), "id")
-			require.Equal(t, 1, c.Len())
-			require.NoError(t, err)
-			require.NotNil(t, val)
+			assert.Equal(t, 1, c.Len())
+			assert.NoError(t, err)
+			assert.NotNil(t, val)
 			events = append(events, "get")
-			close(getCh)
 		}()
 		// sleeping to make sure that Get is called
 		time.Sleep(time.Millisecond * 20)
@@ -477,12 +485,12 @@ func Test_OCache_Remove(t *testing.T) {
 
 		var events []string
 		go func() {
+			defer close(getCh)
 			_, err := c.Get(context.TODO(), "id")
-			require.Equal(t, 1, c.Len())
-			require.NoError(t, err)
-			require.NotNil(t, val)
+			assert.Equal(t, 1, c.Len())
+			assert.NoError(t, err)
+			assert.NotNil(t, val)
 			events = append(events, "get")
-			close(getCh)
 		}()
 		// sleeping to make sure that Get is called
 		time.Sleep(time.Millisecond * 20)
@@ -510,11 +518,11 @@ func Test_OCache_Remove(t *testing.T) {
 		time.Sleep(time.Millisecond * 20)
 		var events []string
 		go func() {
+			defer close(removeCh)
 			ok, err := c.Remove(ctx, "id")
-			require.NoError(t, err)
-			require.True(t, ok)
+			assert.NoError(t, err)
+			assert.True(t, ok)
 			events = append(events, "remove")
-			close(removeCh)
 		}()
 		time.Sleep(time.Millisecond * 20)
 		events = append(events, "close")
@@ -539,11 +547,11 @@ func Test_OCache_Remove(t *testing.T) {
 		time.Sleep(time.Millisecond * 20)
 		var events []string
 		go func() {
+			defer close(removeCh)
 			ok, err := c.Remove(ctx, "id")
-			require.NoError(t, err)
-			require.False(t, ok)
+			assert.NoError(t, err)
+			assert.False(t, ok)
 			events = append(events, "remove")
-			close(removeCh)
 		}()
 		time.Sleep(time.Millisecond * 20)
 		events = append(events, "close")
@@ -564,10 +572,10 @@ func Test_OCache_Remove(t *testing.T) {
 		require.NotNil(t, val)
 		assert.Equal(t, 1, c.Len())
 		go func() {
+			defer close(removeCh)
 			ok, err := c.Remove(ctx, "id")
-			require.NoError(t, err)
-			require.True(t, ok)
-			close(removeCh)
+			assert.NoError(t, err)
+			assert.True(t, ok)
 		}()
 		time.Sleep(20 * time.Millisecond)
 		c.GC()
@@ -671,9 +679,16 @@ func TestOCacheFuzzy(t *testing.T) {
 			return NewTestObject(id, tryCloseIds[id], nil), nil
 		}, WithTTL(time.Nanosecond))
 
+		stopGC := make(chan struct{})
+		defer close(stopGC)
 		go func() {
 			for {
-				c.GC()
+				select {
+				case <-stopGC:
+					return
+				default:
+					c.GC()
+				}
 			}
 		}()
 		go func() {
@@ -683,8 +698,8 @@ func TestOCacheFuzzy(t *testing.T) {
 					if err == ErrClosed {
 						return
 					}
-					require.NoError(t, err)
-					require.NotNil(t, val)
+					assert.NoError(t, err)
+					assert.NotNil(t, val)
 				}
 			}
 		}()
@@ -1111,7 +1126,12 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			c, _, release, getDone := newLoadingCache()
 
-			go func() { close(release) }()                                                         // the load publishes e.value ...
+			go func() { close(release) }() // the load publishes e.value ...
+			if i%2 == 1 {
+				// without a yield TryRemove always observes the loading state;
+				// yielding lets half the iterations meet the published state
+				runtime.Gosched()
+			}
 			require.NotPanics(t, func() { _, _ = c.TryRemove("id") }, "TryRemove racing the load") // ... while TryRemove reads it
 			require.NoError(t, <-getDone)
 			require.NoError(t, c.Close())
@@ -1237,12 +1257,82 @@ func TestOCache_CloseBoundedByWedgedLoad(t *testing.T) {
 }
 
 // Add(nil) must be refused: every close path dereferences the value, and the
-// GC one runs on the ticker goroutine where a panic kills the process.
+// GC one runs on the ticker goroutine where a panic kills the process. A
+// typed-nil pointer is the same hazard wrapped in a non-nil interface.
 func TestOCache_AddNilValue(t *testing.T) {
 	c := New(func(loadCtx context.Context, id string) (Object, error) {
 		return NewTestObject(id, true, nil), nil
 	})
 	require.ErrorIs(t, c.Add("id", nil), ErrNilValue)
+	require.ErrorIs(t, c.Add("id", (*testObject)(nil)), ErrNilValue)
 	require.Equal(t, 0, c.Len())
 	require.NoError(t, c.Close())
+}
+
+// A closer that outruns Close's deadline and then declines must not restore
+// its entry into the closed cache — a live value would survive shutdown with
+// no remaining closer. The decline escalates to a real close instead.
+func TestOCache_CloseBoundedByBusyCloser(t *testing.T) {
+	block := make(chan struct{})
+	obj := NewTestObject("id", false, block) // TryClose blocks on block, then declines
+	c := New(func(loadCtx context.Context, id string) (Object, error) {
+		return obj, nil
+	}, WithGCPeriod(0), WithCloseTimeout(50*time.Millisecond)).(*oCache)
+	require.NoError(t, c.Add("id", obj))
+
+	tryRemoveDone := make(chan struct{})
+	go func() {
+		defer close(tryRemoveDone)
+		ok, err := c.TryRemove("id")
+		assert.True(t, ok, "the decline into a closed cache must escalate to a removal")
+		assert.NoError(t, err)
+	}()
+	require.Eventually(t, func() bool {
+		st, ok := entryStateOf(c, "id")
+		return ok && st == entryStateClosing
+	}, time.Second, time.Millisecond)
+
+	awaitClose(t, c, "Close hung behind a busy closer")
+
+	// the closer wakes after Close gave up on it and declines
+	close(block)
+	<-tryRemoveDone
+	require.True(t, obj.closeCalled, "the declined value must be closed, not resurrected")
+	require.Equal(t, 0, c.Len(), "the entry must not survive in the closed cache")
+}
+
+// A panicking loadFunc must not wedge its id: the entry is dropped, waiters
+// get an error rather than (nil, nil), and the panic reaches the loading
+// caller.
+func TestOCache_LoadFuncPanic(t *testing.T) {
+	calls := 0
+	c := New(func(loadCtx context.Context, id string) (Object, error) {
+		calls++
+		if calls == 1 {
+			panic("boom")
+		}
+		return NewTestObject(id, true, nil), nil
+	}, WithGCPeriod(0)).(*oCache)
+
+	func() {
+		defer func() { require.NotNil(t, recover(), "the loadFunc panic must propagate") }()
+		_, _ = c.Get(ctx, "id")
+	}()
+
+	v, err := c.Get(ctx, "id")
+	require.NoError(t, err, "a fresh Get must run a fresh load, not observe the panicked entry")
+	require.NotNil(t, v)
+	require.Equal(t, 2, calls)
+	require.NoError(t, c.Close())
+}
+
+func TestOCache_PickAfterClose(t *testing.T) {
+	c := New(func(loadCtx context.Context, id string) (Object, error) {
+		return NewTestObject(id, true, nil), nil
+	})
+	_, err := c.Get(ctx, "id")
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+	_, err = c.Pick(ctx, "id")
+	require.ErrorIs(t, err, ErrClosed)
 }

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -96,10 +96,10 @@ func TestOCache_Get(t *testing.T) {
 
 		for i := 0; i < l; i++ {
 			go func() {
+				defer func() { res <- struct{}{} }()
 				val, err := c.Get(context.TODO(), "id")
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, obj, val)
-				res <- struct{}{}
 			}()
 		}
 		time.Sleep(time.Millisecond * 10)
@@ -147,8 +147,23 @@ func TestOCache_Get(t *testing.T) {
 		})
 
 		value, err := c.Get(ctx, "id")
-		assert.NotNil(t, err)
+		require.ErrorIs(t, err, ErrNilValue)
 		assert.Nil(t, value)
+		assert.Equal(t, 0, c.Len())
+		assert.NoError(t, c.Close())
+	})
+	t.Run("value is a typed nil", func(t *testing.T) {
+		// the idiomatic `var p *T; return p, nil` mistake: a non-nil interface
+		// wrapping a nil pointer must be refused like a plain nil, or every
+		// close path panics on it
+		c := New(func(ctx context.Context, id string) (value Object, err error) {
+			return (*testObject)(nil), nil
+		})
+
+		value, err := c.Get(ctx, "id")
+		require.ErrorIs(t, err, ErrNilValue)
+		assert.Nil(t, value)
+		assert.Equal(t, 0, c.Len())
 		assert.NoError(t, c.Close())
 	})
 }
@@ -317,13 +332,14 @@ func TestOCache_GC(t *testing.T) {
 
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			<-begin
 			c.GC()
-			wg.Done()
 		}()
 		for i := 0; i < 50; i++ {
 			wg.Add(1)
 			go func(i int) {
+				defer wg.Done()
 				once.Do(func() {
 					close(begin)
 				})
@@ -331,8 +347,7 @@ func TestOCache_GC(t *testing.T) {
 					time.Sleep(time.Millisecond)
 				}
 				_, err := c.Get(context.TODO(), "id")
-				require.NoError(t, err)
-				wg.Done()
+				assert.NoError(t, err)
 			}(i)
 		}
 		require.NoError(t, err)
@@ -625,6 +640,7 @@ func TestOCacheFuzzy(t *testing.T) {
 		}, WithTTL(time.Nanosecond))
 
 		stopGC := make(chan struct{})
+		defer close(stopGC)
 		wg := sync.WaitGroup{}
 		go func() {
 			for {
@@ -642,8 +658,8 @@ func TestOCacheFuzzy(t *testing.T) {
 			for j := 0; j < 10; j++ {
 				for i := 0; i < max; i++ {
 					val, err := c.Get(context.TODO(), getId(i))
-					require.NoError(t, err)
-					require.NotNil(t, val)
+					assert.NoError(t, err)
+					assert.NotNil(t, val)
 				}
 			}
 		}()
@@ -657,7 +673,6 @@ func TestOCacheFuzzy(t *testing.T) {
 			}
 		}()
 		wg.Wait()
-		close(stopGC)
 		err := c.Close()
 		require.NoError(t, err)
 		require.Equal(t, 0, c.Len())
@@ -1274,6 +1289,10 @@ func TestOCache_AddNilValue(t *testing.T) {
 // no remaining closer. The decline escalates to a real close instead.
 func TestOCache_CloseBoundedByBusyCloser(t *testing.T) {
 	block := make(chan struct{})
+	var unblock sync.Once
+	// unblock on every exit path, or a failed assertion leaks the parked
+	// TryRemove goroutine
+	defer unblock.Do(func() { close(block) })
 	obj := NewTestObject("id", false, block) // TryClose blocks on block, then declines
 	c := New(func(loadCtx context.Context, id string) (Object, error) {
 		return obj, nil
@@ -1295,34 +1314,56 @@ func TestOCache_CloseBoundedByBusyCloser(t *testing.T) {
 	awaitClose(t, c, "Close hung behind a busy closer")
 
 	// the closer wakes after Close gave up on it and declines
-	close(block)
+	unblock.Do(func() { close(block) })
 	<-tryRemoveDone
 	require.True(t, obj.closeCalled, "the declined value must be closed, not resurrected")
 	require.Equal(t, 0, c.Len(), "the entry must not survive in the closed cache")
 }
 
 // A panicking loadFunc must not wedge its id: the entry is dropped, waiters
-// get an error rather than (nil, nil), and the panic reaches the loading
+// get ErrLoadPanic rather than (nil, nil), and the panic reaches the loading
 // caller.
 func TestOCache_LoadFuncPanic(t *testing.T) {
-	calls := 0
+	var (
+		calls   atomic.Int32
+		loading = make(chan struct{})
+		boom    = make(chan struct{})
+	)
 	c := New(func(loadCtx context.Context, id string) (Object, error) {
-		calls++
-		if calls == 1 {
+		if calls.Add(1) == 1 {
+			close(loading)
+			<-boom
 			panic("boom")
 		}
 		return NewTestObject(id, true, nil), nil
 	}, WithGCPeriod(0)).(*oCache)
 
-	func() {
-		defer func() { require.NotNil(t, recover(), "the loadFunc panic must propagate") }()
+	loaderPanic := make(chan any, 1)
+	go func() {
+		defer func() { loaderPanic <- recover() }()
 		_, _ = c.Get(ctx, "id")
 	}()
+	<-loading
+
+	// a waiter parked on the panicking entry's load channel (white-box, so it
+	// deterministically joins this exact entry rather than a fresh load)
+	c.mu.Lock()
+	e := c.data["id"]
+	c.mu.Unlock()
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := e.waitLoad(ctx, "id")
+		waiterErr <- err
+	}()
+
+	close(boom)
+	require.NotNil(t, <-loaderPanic, "the loadFunc panic must propagate to the loading caller")
+	require.ErrorIs(t, <-waiterErr, ErrLoadPanic, "a parked waiter must get an error, not (nil, nil)")
 
 	v, err := c.Get(ctx, "id")
 	require.NoError(t, err, "a fresh Get must run a fresh load, not observe the panicked entry")
 	require.NotNil(t, v)
-	require.Equal(t, 2, calls)
+	require.Equal(t, int32(2), calls.Load())
 	require.NoError(t, c.Close())
 }
 
@@ -1334,5 +1375,26 @@ func TestOCache_PickAfterClose(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.Close())
 	_, err = c.Pick(ctx, "id")
+	require.ErrorIs(t, err, ErrClosed)
+}
+
+// White-box: no public path leaves a loaded entry behind after Close, so the
+// closed-cache guards on ForEach and Pick are pinned against a planted one.
+func TestOCache_ForEachAfterClose(t *testing.T) {
+	c := New(func(loadCtx context.Context, id string) (Object, error) {
+		return NewTestObject(id, true, nil), nil
+	}).(*oCache)
+	require.NoError(t, c.Close())
+	e := newEntry("id", NewTestObject("id", true, nil), entryStateActive)
+	close(e.load)
+	c.mu.Lock()
+	c.data["id"] = e
+	c.mu.Unlock()
+
+	c.ForEach(func(v Object) bool {
+		t.Error("ForEach must not hand out values from a closed cache")
+		return false
+	})
+	_, err := c.Pick(ctx, "id")
 	require.ErrorIs(t, err, ErrClosed)
 }

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -804,16 +804,8 @@ func TestOCache_RemoveBusyRevertDoubleClose(t *testing.T) {
 
 				// wait until the entry is actually in the closing state
 				require.Eventually(t, func() bool {
-					c.mu.Lock()
-					e, ok := c.data["id"]
-					c.mu.Unlock()
-					if !ok {
-						return false
-					}
-					e.mx.Lock()
-					st := e.state
-					e.mx.Unlock()
-					return st == entryStateClosing
+					st, ok := entryStateOf(c, "id")
+					return ok && st == entryStateClosing
 				}, time.Second, time.Millisecond)
 
 				// 2) removers park on the closing channel.
@@ -923,53 +915,53 @@ func entryStateOf(c *oCache, id string) (state entryState, ok bool) {
 	return e.state, true
 }
 
-// noPanic turns the pre-fix nil-value dereference into a test failure instead
-// of a crashed test binary.
-func noPanic(t *testing.T, what string, f func()) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("%s panicked on a loading entry: %v", what, r)
+// newLoadingCache returns a cache with one Get in flight on "id": the loadFunc
+// has signalled it is running and blocks until release is closed, then
+// publishes obj. getDone receives the Get's result.
+func newLoadingCache(opts ...Option) (c *oCache, obj *testObject, release chan struct{}, getDone chan error) {
+	loading := make(chan struct{})
+	release = make(chan struct{})
+	obj = NewTestObject("id", true, nil)
+	c = New(func(loadCtx context.Context, id string) (Object, error) {
+		close(loading)
+		<-release
+		return obj, nil
+	}, append([]Option{WithGCPeriod(0)}, opts...)...).(*oCache)
+	getDone = make(chan error, 1)
+	go func() {
+		v, err := c.Get(ctx, "id")
+		if err == nil && v != obj {
+			err = fmt.Errorf("Get returned %v, want the loaded object", v)
 		}
+		getDone <- err
 	}()
-	f()
+	<-loading
+	return
 }
 
-// An entry stays in entryStateLoading until oCache.load publishes its value:
-// e.value is nil and e.load is still open. TryRemove used to mark such an entry
-// closing and then call TryClose on that nil value (GO-7333):
-//
-//  1. nil dereference panic in e.value.TryClose;
-//  2. even with the panic recovered - or with a naive bail-out placed after
-//     setClosing has already run - the entry is left parked in
-//     entryStateClosing behind a close channel nobody will ever close (the
-//     load's success path calls setActive(false), which does not close it), so
-//     every later Get/Remove blocks forever in waitClose;
-//  3. e.value is written by oCache.load under c.mu and was read here under no
-//     lock at all.
-//
-// The fix refuses the loading->closing transition inside setClosing, so the
-// try-close paths see prevState == entryStateLoading and give up without
-// touching the value, leaving the in-flight load untouched.
+// awaitClose fails the test when c.Close does not return in time.
+func awaitClose(t *testing.T, c OCache, failMsg string) {
+	t.Helper()
+	closeErr := make(chan error, 1)
+	go func() { closeErr <- c.Close() }()
+	select {
+	case err := <-closeErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second * 2):
+		require.Fail(t, failMsg)
+	}
+}
+
+// A loading entry has a nil value and an open load channel: oCache.load alone
+// publishes e.value and closes e.load. The try-close paths (TryRemove, GC)
+// must refuse such an entry - setClosing refuses the loading->closing
+// transition - and leave the in-flight load untouched. The subtests pin the
+// three ways touching one goes wrong: a nil-value TryClose panic, a Get
+// stranded in waitClose behind a close channel the load never closes, and an
+// unsynchronised read of e.value racing its publication.
 func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 	t.Run("refuses a loading entry and leaves the load running", func(t *testing.T) {
-		var (
-			loading = make(chan struct{})
-			release = make(chan struct{})
-			obj     = NewTestObject("id", true, nil)
-		)
-		c := New(func(loadCtx context.Context, id string) (Object, error) {
-			close(loading)
-			<-release
-			return obj, nil
-		}, WithGCPeriod(0)).(*oCache)
-
-		got := make(chan Object, 1)
-		go func() {
-			v, err := c.Get(ctx, "id")
-			assert.NoError(t, err)
-			got <- v
-		}()
-		<-loading // the load is in flight: the entry is in the map, still loading
+		c, _, release, getDone := newLoadingCache()
 
 		state, ok := entryStateOf(c, "id")
 		require.True(t, ok)
@@ -979,7 +971,7 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 			removed bool
 			err     error
 		)
-		noPanic(t, "TryRemove", func() { removed, err = c.TryRemove("id") })
+		require.NotPanics(t, func() { removed, err = c.TryRemove("id") }, "TryRemove on a loading entry")
 		require.NoError(t, err)
 		require.False(t, removed, "a loading entry has no value to close")
 
@@ -990,8 +982,8 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 
 		close(release)
 		select {
-		case v := <-got:
-			require.Equal(t, obj, v)
+		case err := <-getDone:
+			require.NoError(t, err)
 		case <-time.After(time.Second):
 			require.Fail(t, "the in-flight load never completed")
 		}
@@ -999,28 +991,16 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 	})
 
 	t.Run("a Get arriving after the refused TryRemove is not stranded", func(t *testing.T) {
-		// This is failure mode 2: a Get first calls waitClose, so an entry left
-		// in entryStateClosing parks it on a close channel that the completing
+		// A Get first calls waitClose, so an entry wrongly left in
+		// entryStateClosing parks it on a close channel that the completing
 		// load never closes.
-		var (
-			loading = make(chan struct{})
-			release = make(chan struct{})
-			obj     = NewTestObject("id", true, nil)
-		)
-		c := New(func(loadCtx context.Context, id string) (Object, error) {
-			close(loading)
-			<-release
-			return obj, nil
-		}, WithGCPeriod(0)).(*oCache)
+		c, _, release, firstGet := newLoadingCache()
 
-		firstGet := make(chan error, 1)
-		go func() {
-			_, err := c.Get(ctx, "id")
-			firstGet <- err
-		}()
-		<-loading
-
-		noPanic(t, "TryRemove", func() { _, _ = c.TryRemove("id") })
+		require.NotPanics(t, func() { _, _ = c.TryRemove("id") }, "TryRemove on a loading entry")
+		state, ok := entryStateOf(c, "id")
+		require.True(t, ok)
+		require.Equal(t, entryState(entryStateLoading), state,
+			"a refused TryRemove must leave the entry loading; closing strands the late Get")
 
 		lateGet := make(chan error, 1)
 		go func() {
@@ -1030,7 +1010,9 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 			}
 			lateGet <- err
 		}()
-		time.Sleep(time.Millisecond * 10) // let the late Get reach waitClose/waitLoad
+		// best effort at letting the late Get park before the load completes;
+		// the state assertion above is the deterministic regression pin
+		time.Sleep(time.Millisecond * 10)
 		close(release)
 
 		for _, res := range []chan error{firstGet, lateGet} {
@@ -1051,35 +1033,17 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 		// value today. It would, however, if TryRemove "restored" a refused
 		// entry with setActive(true): the entry would be active with a nil
 		// value and the very next GC pass would dereference it.
-		var (
-			loading = make(chan struct{})
-			release = make(chan struct{})
-			obj     = NewTestObject("id", true, nil)
-		)
-		c := New(func(loadCtx context.Context, id string) (Object, error) {
-			close(loading)
-			<-release
-			return obj, nil
-		}, WithTTL(0), WithGCPeriod(0)).(*oCache)
+		c, _, release, getDone := newLoadingCache(WithTTL(0))
 
-		got := make(chan struct{})
-		go func() {
-			defer close(got)
-			_, err := c.Get(ctx, "id")
-			assert.NoError(t, err)
-		}()
-		<-loading
-
-		noPanic(t, "GC", func() { c.GC() })
-		noPanic(t, "TryRemove", func() { _, _ = c.TryRemove("id") })
-		noPanic(t, "GC", func() { c.GC() })
+		require.NotPanics(t, func() { _, _ = c.TryRemove("id") }, "TryRemove on a loading entry")
+		require.NotPanics(t, func() { c.GC() }, "GC after a refused TryRemove")
 
 		state, ok := entryStateOf(c, "id")
 		require.True(t, ok)
 		require.Equal(t, entryState(entryStateLoading), state)
 
 		close(release)
-		<-got
+		require.NoError(t, <-getDone)
 		require.NoError(t, c.Close())
 	})
 
@@ -1101,14 +1065,7 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 		go func() { _, _ = c.Get(ctx, "id") }()
 		<-loading
 
-		closeErr := make(chan error, 1)
-		go func() { closeErr <- c.Close() }()
-		select {
-		case err := <-closeErr:
-			require.NoError(t, err)
-		case <-time.After(time.Second * 2):
-			require.Fail(t, "Close blocked on an entry that was loading")
-		}
+		awaitClose(t, c, "Close blocked on an entry that was loading")
 		require.True(t, obj.closeCalled, "Close must close an entry that was still loading")
 		require.Equal(t, 0, c.Len())
 	})
@@ -1124,49 +1081,127 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 		go func() { _, _ = c.Get(ctx, "id") }()
 		<-loading
 
-		closeErr := make(chan error, 1)
-		go func() { closeErr <- c.Close() }()
-		select {
-		case err := <-closeErr:
-			require.NoError(t, err)
-		case <-time.After(time.Second * 2):
-			require.Fail(t, "Close blocked on a load it aborted")
-		}
+		awaitClose(t, c, "Close blocked on a load it aborted")
 		require.Equal(t, 0, c.Len())
 	})
 
 	t.Run("TryRemove racing the value publication", func(t *testing.T) {
-		// Failure mode 3: oCache.load writes e.value under c.mu, TryRemove read
-		// it holding neither c.mu nor e.mx. The loadFunc is released by the
-		// TryRemove side, so the write and the read run against each other and
-		// -race can observe the unsynchronised pair.
+		// oCache.load writes e.value under c.mu; TryRemove must not read it
+		// unsynchronised. The loadFunc is released by the TryRemove side, so
+		// the write and the read run against each other and -race can observe
+		// an unguarded pair. 100 iterations give the scheduler room to
+		// overlap them.
 		for i := 0; i < 100; i++ {
-			publish := make(chan struct{})
-			c := New(func(loadCtx context.Context, id string) (Object, error) {
-				<-publish
-				return NewTestObject(id, true, nil), nil
-			}, WithGCPeriod(0)).(*oCache)
-
-			done := make(chan struct{})
-			go func() {
-				defer close(done)
-				_, err := c.Get(ctx, "id")
-				assert.NoError(t, err)
-			}()
-			require.Eventually(t, func() bool {
-				state, ok := entryStateOf(c, "id")
-				return ok && state == entryStateLoading
-			}, time.Second, time.Microsecond*100)
+			c, _, release, getDone := newLoadingCache()
 
 			race := make(chan struct{})
 			go func() {
 				close(race)
-				close(publish) // the load publishes e.value ...
+				close(release) // the load publishes e.value ...
 			}()
 			<-race
-			noPanic(t, "TryRemove", func() { _, _ = c.TryRemove("id") }) // ... while TryRemove reads it
-			<-done
+			require.NotPanics(t, func() { _, _ = c.TryRemove("id") }, "TryRemove racing the load") // ... while TryRemove reads it
+			require.NoError(t, <-getDone)
 			require.NoError(t, c.Close())
 		}
 	})
+}
+
+// tryCloseResultObject reports a fixed TryClose verdict.
+type tryCloseResultObject struct {
+	res         bool
+	err         error
+	closeCalled bool
+}
+
+func (o *tryCloseResultObject) Close() error { o.closeCalled = true; return nil }
+
+func (o *tryCloseResultObject) TryClose(objectTTL time.Duration) (bool, error) { return o.res, o.err }
+
+// A TryClose error must not abandon the acquired closing transition: a value
+// that declined to close stays usable, a value that closed leaves the map.
+func TestOCache_TryRemoveTryCloseError(t *testing.T) {
+	t.Run("declined with an error: entry restored, id stays usable", func(t *testing.T) {
+		obj := &tryCloseResultObject{err: errors.New("transient close error")}
+		c := New(func(loadCtx context.Context, id string) (Object, error) {
+			return obj, nil
+		}, WithGCPeriod(0)).(*oCache)
+		require.NoError(t, c.Add("id", obj))
+
+		ok, err := c.TryRemove("id")
+		require.False(t, ok)
+		require.Error(t, err)
+
+		state, found := entryStateOf(c, "id")
+		require.True(t, found, "the entry must survive a declined TryClose")
+		require.Equal(t, entryState(entryStateActive), state,
+			"a declined entry is restored to active, not parked in closing")
+
+		getCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		v, err := c.Get(getCtx, "id")
+		require.NoError(t, err, "the id must stay usable after a TryClose error")
+		require.Same(t, obj, v)
+		require.NoError(t, c.Close())
+	})
+
+	t.Run("closed with an error: entry removed", func(t *testing.T) {
+		obj := &tryCloseResultObject{res: true, err: errors.New("closed with error")}
+		c := New(func(loadCtx context.Context, id string) (Object, error) {
+			return obj, nil
+		}, WithGCPeriod(0)).(*oCache)
+		require.NoError(t, c.Add("id", obj))
+
+		ok, err := c.TryRemove("id")
+		require.True(t, ok)
+		require.Error(t, err)
+		require.Equal(t, 0, c.Len(), "a closed value must not stay in the map")
+		require.NoError(t, c.Close())
+	})
+}
+
+// RemoveSame matches by pointer identity; nil identifies nothing, in
+// particular not a mid-load entry whose value is still nil.
+func TestOCache_RemoveSameNilValue(t *testing.T) {
+	c, obj, release, getDone := newLoadingCache()
+
+	rmCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	ok, err := c.RemoveSame(rmCtx, "id", nil)
+	require.False(t, ok)
+	require.ErrorIs(t, err, ErrNotExists)
+
+	close(release)
+	require.NoError(t, <-getDone)
+	require.False(t, obj.closeCalled, "RemoveSame(nil) must not close the value a load publishes")
+	require.NoError(t, c.Close())
+}
+
+func TestOCache_AddAfterClose(t *testing.T) {
+	c := New(func(loadCtx context.Context, id string) (Object, error) {
+		return NewTestObject(id, true, nil), nil
+	})
+	require.NoError(t, c.Close())
+	require.ErrorIs(t, c.Add("id", NewTestObject("id", true, nil)), ErrClosed)
+	require.Equal(t, 0, c.Len())
+}
+
+// A loadFunc that ignores cancellation must not wedge Close: its entry
+// forfeits the value after the close deadline instead of holding Close
+// hostage.
+func TestOCache_CloseBoundedByWedgedLoad(t *testing.T) {
+	loading := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	c := New(func(loadCtx context.Context, id string) (Object, error) {
+		close(loading)
+		<-release // deliberately ignores loadCtx
+		return NewTestObject(id, true, nil), nil
+	}, WithGCPeriod(0)).(*oCache)
+	c.closeTimeout = 50 * time.Millisecond
+
+	go func() { _, _ = c.Get(ctx, "id") }()
+	<-loading
+
+	awaitClose(t, c, "Close hung behind a load that ignores cancellation")
 }

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -909,3 +909,264 @@ func TestOCache_CloseClosesHealthyEntriesAfterDeadline(t *testing.T) {
 	}
 	require.Empty(t, notClosed, "entries nobody else holds must still be closed after the deadline")
 }
+
+// entryStateOf reports the state of the entry stored under id, if any.
+func entryStateOf(c *oCache, id string) (state entryState, ok bool) {
+	c.mu.Lock()
+	e, ok := c.data[id]
+	c.mu.Unlock()
+	if !ok {
+		return
+	}
+	e.mx.Lock()
+	defer e.mx.Unlock()
+	return e.state, true
+}
+
+// noPanic turns the pre-fix nil-value dereference into a test failure instead
+// of a crashed test binary.
+func noPanic(t *testing.T, what string, f func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked on a loading entry: %v", what, r)
+		}
+	}()
+	f()
+}
+
+// An entry stays in entryStateLoading until oCache.load publishes its value:
+// e.value is nil and e.load is still open. TryRemove used to mark such an entry
+// closing and then call TryClose on that nil value (GO-7333):
+//
+//  1. nil dereference panic in e.value.TryClose;
+//  2. even with the panic recovered - or with a naive bail-out placed after
+//     setClosing has already run - the entry is left parked in
+//     entryStateClosing behind a close channel nobody will ever close (the
+//     load's success path calls setActive(false), which does not close it), so
+//     every later Get/Remove blocks forever in waitClose;
+//  3. e.value is written by oCache.load under c.mu and was read here under no
+//     lock at all.
+//
+// The fix refuses the loading->closing transition inside setClosing, so the
+// try-close paths see prevState == entryStateLoading and give up without
+// touching the value, leaving the in-flight load untouched.
+func TestOCache_TryRemoveWhileLoading(t *testing.T) {
+	t.Run("refuses a loading entry and leaves the load running", func(t *testing.T) {
+		var (
+			loading = make(chan struct{})
+			release = make(chan struct{})
+			obj     = NewTestObject("id", true, nil)
+		)
+		c := New(func(loadCtx context.Context, id string) (Object, error) {
+			close(loading)
+			<-release
+			return obj, nil
+		}, WithGCPeriod(0)).(*oCache)
+
+		got := make(chan Object, 1)
+		go func() {
+			v, err := c.Get(ctx, "id")
+			assert.NoError(t, err)
+			got <- v
+		}()
+		<-loading // the load is in flight: the entry is in the map, still loading
+
+		state, ok := entryStateOf(c, "id")
+		require.True(t, ok)
+		require.Equal(t, entryState(entryStateLoading), state)
+
+		var (
+			removed bool
+			err     error
+		)
+		noPanic(t, "TryRemove", func() { removed, err = c.TryRemove("id") })
+		require.NoError(t, err)
+		require.False(t, removed, "a loading entry has no value to close")
+
+		state, ok = entryStateOf(c, "id")
+		require.True(t, ok, "TryRemove must not drop an entry it refused")
+		require.Equal(t, entryState(entryStateLoading), state,
+			"the entry must be left loading, not parked in closing")
+
+		close(release)
+		select {
+		case v := <-got:
+			require.Equal(t, obj, v)
+		case <-time.After(time.Second):
+			require.Fail(t, "the in-flight load never completed")
+		}
+		require.NoError(t, c.Close())
+	})
+
+	t.Run("a Get arriving after the refused TryRemove is not stranded", func(t *testing.T) {
+		// This is failure mode 2: a Get first calls waitClose, so an entry left
+		// in entryStateClosing parks it on a close channel that the completing
+		// load never closes.
+		var (
+			loading = make(chan struct{})
+			release = make(chan struct{})
+			obj     = NewTestObject("id", true, nil)
+		)
+		c := New(func(loadCtx context.Context, id string) (Object, error) {
+			close(loading)
+			<-release
+			return obj, nil
+		}, WithGCPeriod(0)).(*oCache)
+
+		firstGet := make(chan error, 1)
+		go func() {
+			_, err := c.Get(ctx, "id")
+			firstGet <- err
+		}()
+		<-loading
+
+		noPanic(t, "TryRemove", func() { _, _ = c.TryRemove("id") })
+
+		lateGet := make(chan error, 1)
+		go func() {
+			v, err := c.Get(ctx, "id")
+			if err == nil && v == nil {
+				err = errors.New("nil value")
+			}
+			lateGet <- err
+		}()
+		time.Sleep(time.Millisecond * 10) // let the late Get reach waitClose/waitLoad
+		close(release)
+
+		for _, res := range []chan error{firstGet, lateGet} {
+			select {
+			case err := <-res:
+				require.NoError(t, err)
+			case <-time.After(time.Second):
+				require.Fail(t, "a caller is stuck on an entry TryRemove parked in closing")
+			}
+		}
+		require.NoError(t, c.Close())
+	})
+
+	t.Run("GC never closes a loading entry", func(t *testing.T) {
+		// GC pre-filters on e.isActive(), and nothing moves an entry back to
+		// loading (newEntry is the only writer of entryStateLoading, and a
+		// fresh entry replaces a removed one), so GC cannot reach a loading
+		// value today. It would, however, if TryRemove "restored" a refused
+		// entry with setActive(true): the entry would be active with a nil
+		// value and the very next GC pass would dereference it.
+		var (
+			loading = make(chan struct{})
+			release = make(chan struct{})
+			obj     = NewTestObject("id", true, nil)
+		)
+		c := New(func(loadCtx context.Context, id string) (Object, error) {
+			close(loading)
+			<-release
+			return obj, nil
+		}, WithTTL(0), WithGCPeriod(0)).(*oCache)
+
+		got := make(chan struct{})
+		go func() {
+			defer close(got)
+			_, err := c.Get(ctx, "id")
+			assert.NoError(t, err)
+		}()
+		<-loading
+
+		noPanic(t, "GC", func() { c.GC() })
+		noPanic(t, "TryRemove", func() { _, _ = c.TryRemove("id") })
+		noPanic(t, "GC", func() { c.GC() })
+
+		state, ok := entryStateOf(c, "id")
+		require.True(t, ok)
+		require.Equal(t, entryState(entryStateLoading), state)
+
+		close(release)
+		<-got
+		require.NoError(t, c.Close())
+	})
+
+	t.Run("Close still closes an entry that was loading", func(t *testing.T) {
+		// Close cancels every in-flight load and then removes the entry. This
+		// loadFunc ignores the cancellation and still produces a value, so the
+		// entry becomes active while Close is waiting on it - Close must end up
+		// closing that value rather than refusing it.
+		var (
+			loading = make(chan struct{})
+			obj     = NewTestObject("id", true, nil)
+		)
+		c := New(func(loadCtx context.Context, id string) (Object, error) {
+			close(loading)
+			<-loadCtx.Done()
+			return obj, nil
+		}, WithGCPeriod(0)).(*oCache)
+
+		go func() { _, _ = c.Get(ctx, "id") }()
+		<-loading
+
+		closeErr := make(chan error, 1)
+		go func() { closeErr <- c.Close() }()
+		select {
+		case err := <-closeErr:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 2):
+			require.Fail(t, "Close blocked on an entry that was loading")
+		}
+		require.True(t, obj.closeCalled, "Close must close an entry that was still loading")
+		require.Equal(t, 0, c.Len())
+	})
+
+	t.Run("Close does not hang on a load it aborted", func(t *testing.T) {
+		var loading = make(chan struct{})
+		c := New(func(loadCtx context.Context, id string) (Object, error) {
+			close(loading)
+			<-loadCtx.Done()
+			return nil, loadCtx.Err()
+		}, WithGCPeriod(0)).(*oCache)
+
+		go func() { _, _ = c.Get(ctx, "id") }()
+		<-loading
+
+		closeErr := make(chan error, 1)
+		go func() { closeErr <- c.Close() }()
+		select {
+		case err := <-closeErr:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 2):
+			require.Fail(t, "Close blocked on a load it aborted")
+		}
+		require.Equal(t, 0, c.Len())
+	})
+
+	t.Run("TryRemove racing the value publication", func(t *testing.T) {
+		// Failure mode 3: oCache.load writes e.value under c.mu, TryRemove read
+		// it holding neither c.mu nor e.mx. The loadFunc is released by the
+		// TryRemove side, so the write and the read run against each other and
+		// -race can observe the unsynchronised pair.
+		for i := 0; i < 100; i++ {
+			publish := make(chan struct{})
+			c := New(func(loadCtx context.Context, id string) (Object, error) {
+				<-publish
+				return NewTestObject(id, true, nil), nil
+			}, WithGCPeriod(0)).(*oCache)
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_, err := c.Get(ctx, "id")
+				assert.NoError(t, err)
+			}()
+			require.Eventually(t, func() bool {
+				state, ok := entryStateOf(c, "id")
+				return ok && state == entryStateLoading
+			}, time.Second, time.Microsecond*100)
+
+			race := make(chan struct{})
+			go func() {
+				close(race)
+				close(publish) // the load publishes e.value ...
+			}()
+			<-race
+			noPanic(t, "TryRemove", func() { _, _ = c.TryRemove("id") }) // ... while TryRemove reads it
+			<-done
+			require.NoError(t, c.Close())
+		}
+	})
+}

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -424,11 +424,15 @@ func Test_OCache_Remove(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, val)
 		assert.Equal(t, 1, c.Len())
-		// try removing the object, so we will wait on closing
+		// try removing the object, so we will wait on closing. Len is not
+		// asserted here: the parked Get re-creates the entry as soon as the
+		// removal completes, so 0 is only ever a transient state.
+		tryRemoveDone := make(chan struct{})
 		go func() {
-			_, err := c.TryRemove("id")
-			require.Equal(t, 0, c.Len())
-			require.NoError(t, err)
+			defer close(tryRemoveDone)
+			ok, err := c.TryRemove("id")
+			assert.True(t, ok)
+			assert.NoError(t, err)
 		}()
 		time.Sleep(time.Millisecond * 20)
 
@@ -447,6 +451,7 @@ func Test_OCache_Remove(t *testing.T) {
 		close(closeCh)
 
 		<-getCh
+		<-tryRemoveDone
 		require.Equal(t, []string{"close", "get"}, events)
 	})
 	t.Run("tryRemove simple - can't be removed", func(t *testing.T) {
@@ -461,10 +466,12 @@ func Test_OCache_Remove(t *testing.T) {
 		require.NotNil(t, val)
 		assert.Equal(t, 1, c.Len())
 		// try removing the object, so we will wait on closing
+		tryRemoveDone := make(chan struct{})
 		go func() {
-			_, err := c.TryRemove("id")
-			require.Equal(t, 1, c.Len())
-			require.NoError(t, err)
+			defer close(tryRemoveDone)
+			ok, err := c.TryRemove("id")
+			assert.False(t, ok)
+			assert.NoError(t, err)
 		}()
 		time.Sleep(time.Millisecond * 20)
 
@@ -483,6 +490,8 @@ func Test_OCache_Remove(t *testing.T) {
 		close(closeCh)
 
 		<-getCh
+		<-tryRemoveDone
+		require.Equal(t, 1, c.Len())
 		require.Equal(t, []string{"close", "get"}, events)
 	})
 	t.Run("test remove while gc, tryClose false", func(t *testing.T) {
@@ -922,8 +931,9 @@ func newLoadingCache(opts ...Option) (c *oCache, obj *testObject, release chan s
 	loading := make(chan struct{})
 	release = make(chan struct{})
 	obj = NewTestObject("id", true, nil)
+	var loadingOnce sync.Once // a retried load must not close(loading) twice
 	c = New(func(loadCtx context.Context, id string) (Object, error) {
-		close(loading)
+		loadingOnce.Do(func() { close(loading) })
 		<-release
 		return obj, nil
 	}, append([]Option{WithGCPeriod(0)}, opts...)...).(*oCache)
@@ -1026,17 +1036,25 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 		require.NoError(t, c.Close())
 	})
 
-	t.Run("GC never closes a loading entry", func(t *testing.T) {
+	t.Run("the try-close path refuses a loading entry", func(t *testing.T) {
 		// GC pre-filters on e.isActive(), and nothing moves an entry back to
 		// loading (newEntry is the only writer of entryStateLoading, and a
 		// fresh entry replaces a removed one), so GC cannot reach a loading
-		// value today. It would, however, if TryRemove "restored" a refused
-		// entry with setActive(true): the entry would be active with a nil
-		// value and the very next GC pass would dereference it.
+		// value through its public path — pin the shared tryCloseEntry helper
+		// directly instead, then check the GC pass as a whole stays inert.
 		c, _, release, getDone := newLoadingCache(WithTTL(0))
 
-		require.NotPanics(t, func() { _, _ = c.TryRemove("id") }, "TryRemove on a loading entry")
-		require.NotPanics(t, func() { c.GC() }, "GC after a refused TryRemove")
+		c.mu.Lock()
+		e := c.data["id"]
+		c.mu.Unlock()
+		var (
+			closed bool
+			err    error
+		)
+		require.NotPanics(t, func() { closed, err = c.tryCloseEntry(e) }, "tryCloseEntry on a loading entry")
+		require.False(t, closed, "a loading entry has no value to close")
+		require.NoError(t, err)
+		require.NotPanics(t, func() { c.GC() }, "GC with a loading entry in the map")
 
 		state, ok := entryStateOf(c, "id")
 		require.True(t, ok)
@@ -1048,10 +1066,10 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 	})
 
 	t.Run("Close still closes an entry that was loading", func(t *testing.T) {
-		// Close cancels every in-flight load and then removes the entry. This
-		// loadFunc ignores the cancellation and still produces a value, so the
-		// entry becomes active while Close is waiting on it - Close must end up
-		// closing that value rather than refusing it.
+		// Close cancels every in-flight load and waits it out. This loadFunc
+		// still produces a value on cancellation; whichever side wins the race
+		// - Close's own pass, or the load's closed-cache branch - the value
+		// must end up closed and the entry gone.
 		var (
 			loading = make(chan struct{})
 			obj     = NewTestObject("id", true, nil)
@@ -1087,19 +1105,13 @@ func TestOCache_TryRemoveWhileLoading(t *testing.T) {
 
 	t.Run("TryRemove racing the value publication", func(t *testing.T) {
 		// oCache.load writes e.value under c.mu; TryRemove must not read it
-		// unsynchronised. The loadFunc is released by the TryRemove side, so
-		// the write and the read run against each other and -race can observe
-		// an unguarded pair. 100 iterations give the scheduler room to
-		// overlap them.
+		// unsynchronised. The release goroutine is not waited for, so
+		// TryRemove observes both the loading and the just-published states
+		// across the 100 iterations, and -race can catch an unguarded pair.
 		for i := 0; i < 100; i++ {
 			c, _, release, getDone := newLoadingCache()
 
-			race := make(chan struct{})
-			go func() {
-				close(race)
-				close(release) // the load publishes e.value ...
-			}()
-			<-race
+			go func() { close(release) }()                                                         // the load publishes e.value ...
 			require.NotPanics(t, func() { _, _ = c.TryRemove("id") }, "TryRemove racing the load") // ... while TryRemove reads it
 			require.NoError(t, <-getDone)
 			require.NoError(t, c.Close())
@@ -1114,7 +1126,13 @@ type tryCloseResultObject struct {
 	closeCalled bool
 }
 
-func (o *tryCloseResultObject) Close() error { o.closeCalled = true; return nil }
+func (o *tryCloseResultObject) Close() error {
+	if o.closeCalled {
+		panic("close called twice")
+	}
+	o.closeCalled = true
+	return nil
+}
 
 func (o *tryCloseResultObject) TryClose(objectTTL time.Duration) (bool, error) { return o.res, o.err }
 
@@ -1156,6 +1174,7 @@ func TestOCache_TryRemoveTryCloseError(t *testing.T) {
 		require.True(t, ok)
 		require.Error(t, err)
 		require.Equal(t, 0, c.Len(), "a closed value must not stay in the map")
+		require.False(t, obj.closeCalled, "TryClose already closed the value; Close must not run on top")
 		require.NoError(t, c.Close())
 	})
 }
@@ -1186,22 +1205,44 @@ func TestOCache_AddAfterClose(t *testing.T) {
 	require.Equal(t, 0, c.Len())
 }
 
-// A loadFunc that ignores cancellation must not wedge Close: its entry
-// forfeits the value after the close deadline instead of holding Close
-// hostage.
+// A loadFunc that ignores cancellation must not wedge Close, and the value it
+// publishes after Close gave up must not leak: the load's closed-cache branch
+// closes it and drops the entry, and waiters get ErrClosed.
 func TestOCache_CloseBoundedByWedgedLoad(t *testing.T) {
 	loading := make(chan struct{})
 	release := make(chan struct{})
-	defer close(release)
+	obj := NewTestObject("id", true, nil)
 	c := New(func(loadCtx context.Context, id string) (Object, error) {
 		close(loading)
 		<-release // deliberately ignores loadCtx
-		return NewTestObject(id, true, nil), nil
-	}, WithGCPeriod(0)).(*oCache)
-	c.closeTimeout = 50 * time.Millisecond
+		return obj, nil
+	}, WithGCPeriod(0), WithCloseTimeout(50*time.Millisecond)).(*oCache)
 
-	go func() { _, _ = c.Get(ctx, "id") }()
+	getDone := make(chan error, 1)
+	go func() {
+		_, err := c.Get(ctx, "id")
+		getDone <- err
+	}()
 	<-loading
 
 	awaitClose(t, c, "Close hung behind a load that ignores cancellation")
+
+	// the forfeited load completes after Close returned
+	close(release)
+	require.ErrorIs(t, <-getDone, ErrClosed, "a waiter must not receive a value from a closed cache")
+	// the Get goroutine is the loader: it ran value.Close inside c.load before
+	// returning, so these reads are ordered after it
+	require.True(t, obj.closeCalled, "the late-published value must be closed by the load itself")
+	require.Equal(t, 0, c.Len(), "the forfeited entry must not stay in the map")
+}
+
+// Add(nil) must be refused: every close path dereferences the value, and the
+// GC one runs on the ticker goroutine where a panic kills the process.
+func TestOCache_AddNilValue(t *testing.T) {
+	c := New(func(loadCtx context.Context, id string) (Object, error) {
+		return NewTestObject(id, true, nil), nil
+	})
+	require.ErrorIs(t, c.Add("id", nil), ErrNilValue)
+	require.Equal(t, 0, c.Len())
+	require.NoError(t, c.Close())
 }

--- a/app/ocache/ocache_test.go
+++ b/app/ocache/ocache_test.go
@@ -802,7 +802,7 @@ func (o *busyRevertObject) TryClose(objectTTL time.Duration) (res bool, err erro
 }
 
 // TestOCache_RemoveBusyRevertDoubleClose reproduces a panic that crashes the
-// process on laptop wake (GO-7332): when a busy TryRemove/GC reverts an entry
+// process on laptop wake: when a busy TryRemove/GC reverts an entry
 // back to active while two or more Remove callers are parked on its close
 // channel, every woken remover re-enters the closing path. The second one
 // overwrites e.close, and both call setClosed -> close(e.close) on the same
@@ -1290,9 +1290,6 @@ func TestOCache_AddNilValue(t *testing.T) {
 func TestOCache_CloseBoundedByBusyCloser(t *testing.T) {
 	block := make(chan struct{})
 	var unblock sync.Once
-	// unblock on every exit path, or a failed assertion leaks the parked
-	// TryRemove goroutine
-	defer unblock.Do(func() { close(block) })
 	obj := NewTestObject("id", false, block) // TryClose blocks on block, then declines
 	c := New(func(loadCtx context.Context, id string) (Object, error) {
 		return obj, nil
@@ -1305,6 +1302,12 @@ func TestOCache_CloseBoundedByBusyCloser(t *testing.T) {
 		ok, err := c.TryRemove("id")
 		assert.True(t, ok, "the decline into a closed cache must escalate to a removal")
 		assert.NoError(t, err)
+	}()
+	// on every exit path unblock the parked TryRemove goroutine AND join it,
+	// so its assertions can never run after the test has completed
+	defer func() {
+		unblock.Do(func() { close(block) })
+		<-tryRemoveDone
 	}()
 	require.Eventually(t, func() bool {
 		st, ok := entryStateOf(c, "id")

--- a/net/pool/pool.go
+++ b/net/pool/pool.go
@@ -195,7 +195,12 @@ func (p *pool) pick(ctx context.Context, source ocache.OCache, id string) (peer.
 	if err != nil {
 		return nil, err
 	}
-	pr := v.(peer.Peer)
+	// the cache can hold an *errObject for a failed dial: resolve through
+	// getPeer like get() does instead of panicking on the type assertion
+	pr, err := getPeer(v)
+	if err != nil {
+		return nil, err
+	}
 	if !pr.IsClosed() {
 		return pr, nil
 	}

--- a/net/pool/pool.go
+++ b/net/pool/pool.go
@@ -23,7 +23,8 @@ type Pool interface {
 	GetOneOf(ctx context.Context, peerIds []string) (peer.Peer, error)
 	// AddPeer adds incoming peer to the pool
 	AddPeer(ctx context.Context, p peer.Peer) (err error)
-	// Pick check if connection with peer exist without dial
+	// Pick checks if a connection with the peer exists, without dialing.
+	// For a peer whose last dial failed it returns the cached dial error.
 	Pick(ctx context.Context, id string) (pr peer.Peer, err error)
 	// Flush removes all connections from the pool
 	Flush(ctx context.Context) error
@@ -112,25 +113,23 @@ func (p *pool) Flush(ctx context.Context) error {
 
 func (p *pool) getIfActive(ctx context.Context, peerIds []string) peer.Peer {
 	for _, peerId := range peerIds {
+		// a cached errObject (failed dial) only disqualifies this peerId,
+		// not the rest of the scan
 		if v, err := p.incoming.Pick(ctx, peerId); err == nil {
-			pr, err := getPeer(v)
-			if err != nil {
-				return nil
+			if pr, err := getPeer(v); err == nil {
+				if !pr.IsClosed() {
+					return pr
+				}
+				_, _ = p.incoming.Remove(ctx, peerId)
 			}
-			if !pr.IsClosed() {
-				return pr
-			}
-			_, _ = p.incoming.Remove(ctx, peerId)
 		}
 		if v, err := p.outgoing.Pick(ctx, peerId); err == nil {
-			pr, err := getPeer(v)
-			if err != nil {
-				return nil
+			if pr, err := getPeer(v); err == nil {
+				if !pr.IsClosed() {
+					return pr
+				}
+				_, _ = p.outgoing.Remove(ctx, peerId)
 			}
-			if !pr.IsClosed() {
-				return pr
-			}
-			_, _ = p.outgoing.Remove(ctx, peerId)
 		}
 	}
 	return nil


### PR DESCRIPTION
Refs anytype-heart GO-7333. Follow-up to #746 (GO-7332), found while reviewing it.

### Problem

`TryRemove` reaches `e.value.TryClose(c.ttl)` on an entry that is still in `entryStateLoading`, where `e.value` is nil:

```go
// app/ocache/ocache.go:319-321 (before)
prevState, _, _ := e.setClosing(context.Background(), false)
if prevState == entryStateClosing || prevState == entryStateClosed {
	return false, nil
}
closed, err := e.value.TryClose(c.ttl)
```

`entryStateLoading` is the zero value of the state (`entry.go:14`) and nothing bailed on it. An entry is loading from `newEntry(id, nil, entryStateLoading)` (`ocache.go:150`) until `oCache.load` publishes the value (`ocache.go:227`), so the window is every in-flight load. Three failure modes:

1. **Nil dereference.** `e.value` is a genuinely nil `Object`, so the method call panics — and it panics in the caller's goroutine, taking the process with it.
2. **Permanent hang.** `setClosing` flips the entry loading→closing and creates a fresh `e.close`, but `e.load` is closed only by `defer close(e.load)` inside `oCache.load`, and the load's success path calls `setActive(false)`, which does *not* close `e.close`. Any later `Get` (`waitClose` first) parks on that channel forever.
3. **Data race on `e.value`.** `oCache.load` writes it under `c.mu` (`ocache.go:227`); `TryRemove` read it after releasing `c.mu`, holding neither `c.mu` nor `e.mx`. `-race` on the new test reports exactly this pair before the fix.

`TryRemove` has no production callers inside any-sync (tests only), but anytype-heart calls it on a high-volume path — `core/indexer/fulltext.go` `TryRemoveFromCache` after every fulltext index of an object, plus `core/block/editor/layout/syncer.go` — so the exposure is real, gated only on the object still being loaded elsewhere.

### Fix

`setClosing` refuses the transition for a loading entry instead of performing it, and the two try-close paths (`TryRemove`, `GC`) act only when `prevState == entryStateActive` — the state in which the call actually acquired the transition.

**Why the transition must be prevented, not undone or skipped.** Adding `|| prevState == entryStateLoading` to the old bail condition does not fix the bug, it converts failure mode 1 into failure mode 2: by the time the caller sees `prevState`, `setClosing` has already run `e.state = entryStateClosing; e.close = make(chan struct{})`, so the entry stays parked in closing with an `e.load` that is still open and an `e.close` nobody will close. Restoring with `setActive(true)` is worse: it marks the entry active while `e.value` is still nil, so the very next `GC` pass — which pre-filters on `e.isActive()` — walks straight into the same nil dereference. Both variants were implemented and run against the new test: the naive bail-out fails on the stranded-`Get` subtest (and leaves `Close` eating its full timeout), and the `setActive(true)` variant fails with `GC panicked on a loading entry: invalid memory address or nil pointer dereference`.

### The other two setClosing callers

- `removeCtx` (`ocache.go:268`, `wait=true`; used by `Remove`, `RemoveSame`, `Close`) calls `e.waitLoad` first, and `<-e.load` is closed only after the load has either set the value and called `setActive` or recorded `loadErr` and deleted the entry — so it never arrives here in the loading state. If it somehow did, it now gets `curState != entryStateClosing` → `(false, nil)`, which is a safe refusal rather than a nil `Close()`. `Close` still cancels every in-flight load (`e.cancelLoad()`) and then closes the value the load produces; two new subtests pin that, one where the loadFunc ignores the cancellation and yields a value (it must be closed) and one where it honours it (`Close` must not hang).
- `GC` (`ocache.go:413`) builds `toClose` from `e.isActive()` entries. The window between that check and `setClosing` cannot expose a loading entry: `entryStateLoading` is written in exactly one place, `newEntry` (`ocache.go:150`), and a removed entry is replaced by a fresh one rather than reset, so there is no active→loading edge. The `prevState != entryStateActive` change there is defensive and behaviourally identical for closing/closed; it is what keeps the `setActive(true)` trap above from being reachable through GC.

The GO-7332 `for e.state == entryStateClosing` loop is untouched — the new guard sits above it, and the loading state never enters that loop anyway (the loop's exit states are active/closed, never loading).

### Test

`TestOCache_TryRemoveWhileLoading` (`app/ocache/ocache_test.go`), deterministic — the loadFunc signals when it is in flight and is released by the test, in the style of the existing load-synchronising tests:

- `refuses a loading entry and leaves the load running` — mode 1: `TryRemove` returns `(false, nil)` without panicking, the entry is still `entryStateLoading` afterwards, and the in-flight `Get` completes with its value.
- `a Get arriving after the refused TryRemove is not stranded` — mode 2: a `Get` issued after `TryRemove` must not park forever in `waitClose`.
- `GC never closes a loading entry` — GC before and after a refused `TryRemove`, catching the `setActive(true)` restore variant.
- `Close still closes an entry that was loading` / `Close does not hang on a load it aborted` — the shared-behaviour change to `setClosing` does not regress cache shutdown.
- `TryRemove racing the value publication` — mode 3: the load publishes `e.value` while `TryRemove` reads it, so `-race` observes the pair (100 iterations).

Verification:

```
$ go test ./app/ocache/... -race -count=1
ok  	github.com/anyproto/any-sync/app/ocache	3.522s
$ go test ./app/ocache/... -race -count=10
ok  	github.com/anyproto/any-sync/app/ocache	59.218s
$ go test ./acl/... ./commonspace/... ./net/... -race -count=1   # every package importing ocache
ok  (35 packages, no failures)
```