### PR TITLE
subscribe to head storage from Init and fix quic close test sync

### DIFF
--- a/commonspace/headsync/diffsyncer.go
+++ b/commonspace/headsync/diffsyncer.go
@@ -70,14 +70,18 @@ type diffSyncer struct {
 func (d *diffSyncer) Init() {
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	d.headUpdater = newHeadUpdater(d.updateHeads)
+	// Subscribe here rather than in Run: app.Start finishes every component's
+	// Init before the first Run, so registration cannot race a component that
+	// already Run and dispatches through UpdateEntry (deletionmanager starts
+	// its delete loop that way). Updates arriving before Run are buffered.
+	d.storage.HeadStorage().AddObserver(d)
 }
 
-// Run starts the headUpdater goroutine and subscribes to head storage updates.
-// It must not be called from Init: if another component fails to Run, the
-// space app never reaches headSync.Close, and a goroutine started in Init
-// would leak together with everything it references (see diffSyncer fields).
+// Run starts the headUpdater goroutine, draining whatever Init buffered. The
+// goroutine must not start in Init: if another component fails to Run, the
+// space app never reaches headSync.Close, and it would leak together with
+// everything it references (see diffSyncer fields).
 func (d *diffSyncer) Run() {
-	d.storage.HeadStorage().AddObserver(d)
 	d.headUpdater.Run()
 }
 

--- a/commonspace/headsync/headstorage/headstorage.go
+++ b/commonspace/headsync/headstorage/headstorage.go
@@ -113,7 +113,9 @@ func New(ctx context.Context, store anystore.DB) (HeadStorage, error) {
 }
 
 func (h *headStorage) AddObserver(observer Observer) {
-	// we don't take lock here, because it shouldn't happen during the program execution
+	// no lock: observers are registered from a component's Init, and app.Start
+	// finishes every Init before the first Run, so no goroutine can be
+	// dispatching through UpdateEntry yet
 	h.observers = append(h.observers, observer)
 }
 

--- a/net/transport/quic/quic_test.go
+++ b/net/transport/quic/quic_test.go
@@ -317,11 +317,13 @@ func TestQuicMultiConn_Close(t *testing.T) {
 		}
 
 		done := make(chan struct{})
-		mockConn.EXPECT().CloseWithError(quic.ApplicationErrorCode(2), "").DoAndReturn(func(quic.ApplicationErrorCode, string) error {
+		mockConn.EXPECT().CloseWithError(quic.ApplicationErrorCode(2), "").Return(nil)
+		// udpConn.Close is the last call Close makes; releasing on
+		// CloseWithError lets ctrl.Finish run before it
+		mockUdpConn.EXPECT().Close().DoAndReturn(func() error {
 			close(done)
 			return nil
 		})
-		mockUdpConn.EXPECT().Close().Return(nil)
 
 		err := q.Close()
 		assert.NoError(t, err)
@@ -375,11 +377,13 @@ func TestQuicMultiConn_Close(t *testing.T) {
 		}
 
 		done := make(chan struct{})
-		mockConn.EXPECT().CloseWithError(quic.ApplicationErrorCode(2), "").DoAndReturn(func(quic.ApplicationErrorCode, string) error {
+		mockConn.EXPECT().CloseWithError(quic.ApplicationErrorCode(2), "").Return(nil)
+		// udpConn.Close is the last call Close makes; releasing on
+		// CloseWithError lets ctrl.Finish run before it
+		mockUdpConn.EXPECT().Close().DoAndReturn(func() error {
 			close(done)
-			return nil
+			return errors.New("udp error")
 		})
-		mockUdpConn.EXPECT().Close().Return(errors.New("udp error"))
 
 		err := q.Close()
 		assert.NoError(t, err)


### PR DESCRIPTION
`go test -race ./...` fails on main. Both failures predate the v0.13.x PRs and reproduce at `v0.13.1`.

## headstorage observer race

`app.Start` runs **every component's `Init` before the first `Run`**, so registration during Init cannot race — that is the invariant `AddObserver`'s lock-free append relies on. `diffSyncer` broke it by subscribing from `Run`: in `spaceservice.go` `deletionmanager` is registered at 245 and `headsync` last at 251, and `deleteLoop.loop` calls `deleteFunc` as its first statement. So the delete loop was already dispatching through `UpdateEntry` while `headSync.Run` appended to the observer slice.

Registration moves to `Init`, restoring the invariant, so head storage stays lock-free rather than growing a mutex to defend an assumption the caller was violating.

The `headUpdater` goroutine stays in `Run` — the leak reason documented there is about the goroutine, not the subscription. Updates arriving before it starts are buffered by the batcher (unbounded `mb`, created in `Init`), so they are now processed instead of dropped as they were while the observer sat unregistered between `deletionmanager.Run` and `headsync.Run`.

`headstorage.AddObserver` has no callers outside `diffSyncer` — in any-sync, any-sync-node, or any-sync-sdk2. Both downstream repos register `commonspace.New()` and inherit the spaceApp built here, so the ordering is owned entirely by this repo.

## TestQuicMultiConn_Close

Two subtests released `done` from the `CloseWithError` expectation, but `udpConn.Close` is the last call `Close` makes, so `ctrl.Finish` could run first and report `missing call(s) to MockPacketConn.Close`. Both now release on `udpConn.Close`, matching the sibling subtest.

`go test -race ./...` is green (57 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXNxMzxa6rK3bAwcULTt4x