### PR TITLE
fill the diff before draining buffered head updates

### DIFF
--- a/commonspace/headsync/headsync.go
+++ b/commonspace/headsync/headsync.go
@@ -97,10 +97,13 @@ func (h *headSync) Name() (name string) {
 }
 
 func (h *headSync) Run(ctx context.Context) (err error) {
-	h.syncer.Run()
+	// FillDiff first: it bulk-Sets the diff from a storage snapshot, so a
+	// concurrent drain would have its RemoveId/Set undone by that snapshot.
+	// Draining after means buffered updates apply on top and converge.
 	if err := h.diffManager.FillDiff(ctx); err != nil {
 		return err
 	}
+	h.syncer.Run()
 	h.periodicSync.Run()
 	return
 }


### PR DESCRIPTION
Follow-up to #772.

`FillDiff` bulk-`Set`s the diff from a storage snapshot. With the drain goroutine started first, a `RemoveId` the drain had just applied got undone by that older snapshot — resurrecting a deleted tree in the diff and persisting a space hash for a tree the space no longer has. Nothing corrected it afterwards, so head sync kept advertising the tree until the next unrelated update for that id.

The race predates #772, but #772 made it reachable: subscribing from `Init` means updates buffer for the whole Run phase (~13 components) instead of being dropped, so the drain flushes a burst at exactly the moment `FillDiff` runs. Previously the window was microseconds and nothing was pending.

Filling first makes the storage snapshot the baseline and lets buffered updates apply on top, where they converge — the last queued event for an id always matches storage. The reverse order could not converge, because the bulk `Set` had no later event to correct it.

`FillDiff` stays in `Run`: it is ctx-bound I/O that can fail, and `Init` has no context. Only the two statements swap — no component lifecycle changes.

`go test -race ./...` green (58 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXNxMzxa6rK3bAwcULTt4x