### PR TITLE
evict an outgoing peer that closed before the cache published it

### DIFF
--- a/net/pool/pool.go
+++ b/net/pool/pool.go
@@ -64,6 +64,15 @@ func (p *pool) evictOnClose(pr peer.Peer, cache ocache.OCache, inbound bool) {
 		// pool is shutting down; let cache.Close handle eviction
 		return
 	}
+	if !inbound {
+		// The outgoing watcher is started from inside the ocache load func,
+		// before the value is published, and RemoveSame deliberately never
+		// matches a still-loading entry. A connection dying that early would
+		// otherwise leave the closed peer to be published with no watcher
+		// left to evict it. Pick waits the load out; incoming peers are
+		// published synchronously by AddPeer and need no wait.
+		_, _ = cache.Pick(p.closingCtx, pr.Id())
+	}
 	// Remove only if the cache still holds THIS peer. A newer connection for
 	// the same id may have replaced pr (incoming AddPeer re-add, or outgoing
 	// redial); removing by id alone would close that live replacement.

--- a/net/pool/pool_test.go
+++ b/net/pool/pool_test.go
@@ -1014,3 +1014,38 @@ func (o *countingPanickyObserver) ObservePeerEvent(peerobserver.Event) {
 	o.calls.Add(1)
 	panic("observer panic")
 }
+
+func TestPool_EvictsOutgoingClosedDuringLoad(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.Finish()
+
+	p := fx.Service.(*poolService).pool
+	tp := newTestPeer("1")
+
+	loading := make(chan struct{})
+	release := make(chan struct{})
+	cache := ocache.New(func(ctx context.Context, id string) (ocache.Object, error) {
+		close(loading)
+		<-release
+		return tp, nil
+	})
+
+	go func() { _, _ = cache.Get(ctx, "1") }()
+	<-loading
+
+	// the connection dies while the entry is still loading, which is when the
+	// outgoing watcher is started: RemoveSame cannot match a nil-value entry
+	require.NoError(t, tp.Close())
+	done := make(chan struct{})
+	go func() {
+		p.evictOnClose(tp, cache, false)
+		close(done)
+	}()
+
+	// let the watcher reach RemoveSame before the value is published
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	<-done
+	require.Equal(t, 0, cache.Len(), "closed peer must not stay cached after the load publishes")
+}


### PR DESCRIPTION
Not a regression from this release train — the structure dates to `08f8d6d3` (PR #693, `go-7301-quic-pool-eviction`, 2026-06-01) and has shipped since **v0.12.6**. #773 made one consequence newly visible by adding the `KindClosed` notification to `evictOnClose`.

The outgoing watcher is started from inside the ocache load func, before the value is published. `RemoveSame` deliberately never matches a still-loading entry — its comment is explicit that matching a nil value would wait the load out and close whatever the load publishes. So a connection dying in that window meant:

- the watcher's `RemoveSame` returned `ErrNotExists` and the watcher exited, leaving the closed peer to be published with **no watcher at all** — it lingered until the next `Get` self-healed it or the TTL reaped it;
- the observer reported `KindClosed` for a peer the pool had not yet accepted (no preceding `KindConnected`).

Waiting the load out via `Pick` before removing fixes both, and keeps the existing "never close a live replacement" invariant: `RemoveSame` still only removes this exact peer, so if another value took the id nothing happens. Incoming peers are published synchronously by `AddPeer`, so that path removes without a wait and is untouched.

`TestPool_EvictsOutgoingClosedDuringLoad` drives the seam directly — a load held open while the peer closes — and fails without the fix (`closed peer must not stay cached after the load publishes`).

`go test -race ./net/pool/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXNxMzxa6rK3bAwcULTt4x